### PR TITLE
Adds the possiblity to use replacement tags in a TrackingScript

### DIFF
--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>7.15.58</Version>
+    <Version>7.15.59</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -14,8 +14,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.58.0</AssemblyVersion>
-    <FileVersion>7.15.58.0</FileVersion>
+    <AssemblyVersion>7.15.59.0</AssemblyVersion>
+    <FileVersion>7.15.59.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sushi.Mediakiwi.Headless/Data/TrackingScript/TrackingScriptReplacementItem.cs
+++ b/src/Sushi.Mediakiwi.Headless/Data/TrackingScript/TrackingScriptReplacementItem.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sushi.Mediakiwi.Headless.Data.TrackingScript
+{
+    public class TrackingScriptReplacementItem
+    {
+        [JsonPropertyName("code")]
+        public string Code { get; set; }
+        
+        [JsonPropertyName("fallBack")]
+        public string Fallback { get; set; }
+        
+        [JsonPropertyName("mustBeFilled")]
+        public bool MustBeFilled { get; set; }
+
+        [JsonPropertyName("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Sushi.Mediakiwi.Headless/Data/TrackingScript/TrackingScriptSimple.cs
+++ b/src/Sushi.Mediakiwi.Headless/Data/TrackingScript/TrackingScriptSimple.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Sushi.Mediakiwi.Headless.Data.TrackingScript
@@ -36,5 +37,8 @@ namespace Sushi.Mediakiwi.Headless.Data.TrackingScript
 
         [JsonPropertyName("isActive")]
         public bool IsActive { get; set; }
+
+        [JsonPropertyName("replacementItems")]
+        public List<TrackingScriptReplacementItem> ReplacementItems { get; set; } = new List<TrackingScriptReplacementItem>();
     }
 }

--- a/src/Sushi.Mediakiwi.Headless/IScriptTagContentResolver.cs
+++ b/src/Sushi.Mediakiwi.Headless/IScriptTagContentResolver.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Sushi.Mediakiwi.Headless
+{
+    public interface IScriptTagContentResolver
+    {
+        Task SetContentAsync(Data.PageContentResponse pageContent, string url, List<Data.TrackingScript.TrackingScriptSimple> scripts);
+    }
+}

--- a/src/Sushi.Mediakiwi.Headless/ScriptTagHelperComponent.cs
+++ b/src/Sushi.Mediakiwi.Headless/ScriptTagHelperComponent.cs
@@ -24,10 +24,10 @@ namespace Sushi.Mediakiwi.Headless
             if (script?.ReplacementItems?.Count > 0)
             {
                 // Are all marked as mandatory ?
-                var allMandatory = script.ReplacementItems.Count == script.ReplacementItems.Count(x => x.MustBeFilled);
+                var allMandatory = script.ReplacementItems.All(x => x.MustBeFilled);
 
                 // are all values filled ?
-                var allFilled = script.ReplacementItems.Count == script.ReplacementItems.Count(x => string.IsNullOrWhiteSpace(x.Value) == false);
+                var allFilled = script.ReplacementItems.All(x => string.IsNullOrWhiteSpace(x.Value) == false);
 
                 // if all replacement values are marked as mandatory, but not all are filled, empty the code.
                 if (allMandatory && !allFilled) 

--- a/src/Sushi.Mediakiwi.Headless/ScriptTagHelperComponent.cs
+++ b/src/Sushi.Mediakiwi.Headless/ScriptTagHelperComponent.cs
@@ -19,6 +19,40 @@ namespace Sushi.Mediakiwi.Headless
         [ViewContext]
         public ViewContext ViewContext { get; set; }
 
+        private void PerformReplacements(TrackingScriptSimple script)
+        {
+            if (script?.ReplacementItems?.Count > 0)
+            {
+                // Are all marked as mandatory ?
+                var allMandatory = script.ReplacementItems.Count == script.ReplacementItems.Count(x => x.MustBeFilled);
+
+                // are all values filled ?
+                var allFilled = script.ReplacementItems.Count == script.ReplacementItems.Count(x => string.IsNullOrWhiteSpace(x.Value) == false);
+
+                // if all replacement values are marked as mandatory, but not all are filled, empty the code.
+                if (allMandatory && !allFilled) 
+                {
+                    script.Code = string.Empty;
+                    return;
+                }
+
+                // Only continue when we have a non-empty code
+                if (string.IsNullOrWhiteSpace(script.Code) == false)
+                {
+                    foreach (var repitem in script.ReplacementItems)
+                    {
+                        if (string.IsNullOrWhiteSpace(repitem.Value) == false)
+                        {
+                            script.Code = script.Code.Replace($"[{repitem.Code}]", repitem.Value, StringComparison.InvariantCultureIgnoreCase);
+                        }
+                        else if (string.IsNullOrWhiteSpace(repitem.Fallback) == false)
+                        {
+                            script.Code = script.Code.Replace($"[{repitem.Code}]", repitem.Fallback, StringComparison.InvariantCultureIgnoreCase);
+                        }
+                    }
+                }
+            }
+        }
 
         public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
@@ -35,10 +69,14 @@ namespace Sushi.Mediakiwi.Headless
 
             if (ViewContext.HttpContext.Items.ContainsKey(ContextItemNames.ScriptTags))
             {
-                if (ViewContext.HttpContext.Items[ContextItemNames.ScriptTags] is List<TrackingScriptSimple>)
-                    availableScriptTags = (List<TrackingScriptSimple>)ViewContext.HttpContext.Items[ContextItemNames.ScriptTags];
-                else if (ViewContext.HttpContext.Items[ContextItemNames.ScriptTags] is TrackingScriptSimple)
-                    availableScriptTags.Add((TrackingScriptSimple)ViewContext.HttpContext.Items[ContextItemNames.ScriptTags]);
+                if (ViewContext.HttpContext.Items[ContextItemNames.ScriptTags] is List<TrackingScriptSimple> scriptList)
+                {
+                    availableScriptTags = scriptList;
+                }
+                else if (ViewContext.HttpContext.Items[ContextItemNames.ScriptTags] is TrackingScriptSimple scriptItem)
+                {
+                    availableScriptTags.Add(scriptItem);
+                }
             }
 
             if (availableScriptTags?.Count > 0)
@@ -54,17 +92,29 @@ namespace Sushi.Mediakiwi.Headless
                 {
                     foreach (var script in headAfterCloseTags)
                     {
-                        output.PostElement.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PostElement.AppendHtmlLine(script.Code);
+                        }
                     }
 
                     foreach (var script in headAfterOpenTags)
                     {
-                        output.PreContent.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PreContent.AppendHtmlLine(script.Code);
+                        }
                     }
 
                     foreach (var script in headBeforeCloseTags)
                     {
-                        output.PostContent.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PostContent.AppendHtmlLine(script.Code);
+                        }
                     }
                 }
 
@@ -72,17 +122,29 @@ namespace Sushi.Mediakiwi.Headless
                 {
                     foreach (var script in bodyAfterCloseTags)
                     {
-                        output.PostElement.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PostElement.AppendHtmlLine(script.Code);
+                        }
                     }
 
                     foreach (var script in bodyAfterOpenTags)
                     {
-                        output.PreContent.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PreContent.AppendHtmlLine(script.Code);
+                        }
                     }
 
                     foreach (var script in bodyBeforeCloseTags)
                     {
-                        output.PostContent.AppendHtmlLine(script.Code);
+                        PerformReplacements(script);
+                        if (string.IsNullOrWhiteSpace(script.Code) == false)
+                        {
+                            output.PostContent.AppendHtmlLine(script.Code);
+                        }
                     }
                 }
 

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.58</Version>
+    <Version>7.15.59</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -11,8 +11,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://mediakiwi.atlassian.net/wiki/spaces/CORE/overview</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Supershift/Sushi.Mediakiwi</RepositoryUrl>
-    <AssemblyVersion>7.15.58.0</AssemblyVersion>
-    <FileVersion>7.15.58.0</FileVersion>
+    <AssemblyVersion>7.15.59.0</AssemblyVersion>
+    <FileVersion>7.15.59.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.58</Version>
+    <Version>7.15.59</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>
@@ -15,8 +15,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.58.0</AssemblyVersion>
-    <FileVersion>7.15.58.0</FileVersion>
+    <AssemblyVersion>7.15.59.0</AssemblyVersion>
+    <FileVersion>7.15.59.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
An implementation of IScriptTagContentResolver can be added to a web project to enable page / url-dependant replacement values which will be replaced in the eventual output of the TrackingScript code.

To use this new feature, add the following code to the startup class :
`services.AddTransient<IScriptTagContentResolver, ScriptTagContentResolver>();`
After 
`services.AddMediaKiwiContentService();`

Where **ScriptTagContentResolver** is the class implementing the **IScriptTagContentResolver** interface
