### PR TITLE
Returns the need for a cache flush from the ContentController

### DIFF
--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>7.15.61</Version>
+    <Version>7.15.62</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -14,7 +14,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.61.0</AssemblyVersion>
+    <AssemblyVersion>7.15.62.0</AssemblyVersion>
     <FileVersion>7.15.61.0</FileVersion>
   </PropertyGroup>
 

--- a/src/Sushi.Mediakiwi.Headless/BaseRazorComponent.cs
+++ b/src/Sushi.Mediakiwi.Headless/BaseRazorComponent.cs
@@ -72,7 +72,7 @@ namespace Sushi.Mediakiwi.Headless
                 var propertyInfos = this.GetType().GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
                 foreach (var propInfo in propertyInfos)
                 {
-                    var contentProp = Content.Content.Where(x => x.Key == propInfo.Name).FirstOrDefault();
+                    var contentProp = Content.Content.FirstOrDefault(x => x.Key == propInfo.Name);
                     if (contentProp.Value != null)
                     {
                         propInfo.SetValue(this, contentProp.Value);
@@ -115,7 +115,7 @@ namespace Sushi.Mediakiwi.Headless
                 var propertyInfos = this.GetType().GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
                 foreach (var propInfo in propertyInfos)
                 {
-                    var contentProp = Content.Content.Where(x => x.Key == propInfo.Name).FirstOrDefault();
+                    var contentProp = Content.Content.FirstOrDefault(x => x.Key == propInfo.Name);
                     if (contentProp.Value != null)
                     {
                         propInfo.SetValue(this, contentProp.Value);

--- a/src/Sushi.Mediakiwi.Headless/Data/ContentMetaData.cs
+++ b/src/Sushi.Mediakiwi.Headless/Data/ContentMetaData.cs
@@ -49,7 +49,9 @@ namespace Sushi.Mediakiwi.Headless.Data
             get
             {
                 if (MetaTags?.Count > 0)
-                    return MetaTags?.Where(x => x.Name == key).FirstOrDefault();
+                {
+                    return MetaTags?.FirstOrDefault(x => x.Name == key);
+                }
 
                 return null;
             }
@@ -80,7 +82,7 @@ namespace Sushi.Mediakiwi.Headless.Data
             }
             else if (overWriteIfExists)
             {
-                ContentMetaTag metaTag = MetaTags.Where(x => x.Name == name).FirstOrDefault();
+                ContentMetaTag metaTag = MetaTags.FirstOrDefault(x => x.Name == name);
                 metaTag.Value = content;
                 metaTag.RenderKey = renderKey;
             }

--- a/src/Sushi.Mediakiwi.Headless/Data/PageContentResponse.cs
+++ b/src/Sushi.Mediakiwi.Headless/Data/PageContentResponse.cs
@@ -18,18 +18,6 @@ namespace Sushi.Mediakiwi.Headless.Data
         }
 
         /// <summary>
-        /// Is the response a cached response
-        /// </summary>
-        [DataMember(Name = "cached")]
-        public bool IsCached { get; set; }
-
-        /// <summary>
-        /// Is the response a cached response
-        /// </summary>
-        [DataMember(Name = "invalidCache")]
-        public bool IsCacheInvalidated { get; set; }
-
-        /// <summary>
         /// The PadeID from mediakiwi
         /// </summary>
         [DataMember(Name = "pageId")]

--- a/src/Sushi.Mediakiwi.Headless/MediaKiwiRewriteRule.cs
+++ b/src/Sushi.Mediakiwi.Headless/MediaKiwiRewriteRule.cs
@@ -74,8 +74,8 @@ namespace Sushi.Mediakiwi.Headless
                     }
 
                     response.Headers.Add(HttpHeaderNames.TimeSpend,new TimeSpan(dt2.Ticks - dt1.Ticks).TotalMilliseconds.ToString());
-                    response.Headers.Add(HttpHeaderNames.CachedData, PageContent.IsCached.ToString());
-                    response.Headers.Add(HttpHeaderNames.CacheInvalidData, PageContent.IsCacheInvalidated.ToString());
+                    response.Headers.Add(HttpHeaderNames.CachedData, (PageContent?.InternalInfo?.ClearCache == false).ToString());
+                    //response.Headers.Add(HttpHeaderNames.CacheInvalidData, PageContent.IsCacheInvalidated.ToString());
 
                     // apply the proper status code based on the headless result
                     response.StatusCode = (int)PageContent.StatusCode;

--- a/src/Sushi.Mediakiwi.Headless/SlotTagHelper.cs
+++ b/src/Sushi.Mediakiwi.Headless/SlotTagHelper.cs
@@ -141,6 +141,9 @@ namespace Sushi.Mediakiwi.Headless
 
                             if (compType != null)// && compType.IsAssignableFrom(typeof(Microsoft.AspNetCore.Mvc.ViewComponent)))
                             {
+                                comp.InternalInfo.ClearCache = cont.InternalInfo.ClearCache || ViewContext.HttpContext.Request.IsClearCacheCall();
+                                comp.InternalInfo.IsPreview = cont.InternalInfo.IsPreview || ViewContext.HttpContext.Request.IsPreviewCall();
+
                                 var type = Type.GetType("Microsoft.AspNetCore.Mvc.ViewFeatures.IComponentRenderer, Microsoft.AspNetCore.Mvc.ViewFeatures, Version=3.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60");
                                 var componentRenderer = ViewContext.HttpContext.RequestServices.GetRequiredService(type);
                                 var method = type.GetMethod("RenderComponentAsync");
@@ -155,10 +158,10 @@ namespace Sushi.Mediakiwi.Headless
                                 Parameters[nameof(BaseRazorComponent<ISushiApplicationSettings>.PageMetaData)] = cont.MetaData;
 
                                 // Set ClearCache property
-                                Parameters[nameof(BaseRazorComponent<ISushiApplicationSettings>.ClearCache)] = ViewContext.HttpContext.Request.IsClearCacheCall();
+                                Parameters[nameof(BaseRazorComponent<ISushiApplicationSettings>.ClearCache)] = comp.InternalInfo.ClearCache;
 
                                 // Set IsPreview property
-                                Parameters[nameof(BaseRazorComponent<ISushiApplicationSettings>.IsPreview)] = ViewContext.HttpContext.Request.IsPreviewCall();
+                                Parameters[nameof(BaseRazorComponent<ISushiApplicationSettings>.IsPreview)] = comp.InternalInfo.IsPreview;
 
                                 // Get dynamic property
                                 var tempComp = Activator.CreateInstance(compType);

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.61</Version>
+    <Version>7.15.62</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -11,8 +11,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://mediakiwi.atlassian.net/wiki/spaces/CORE/overview</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Supershift/Sushi.Mediakiwi</RepositoryUrl>
-    <AssemblyVersion>7.15.61.0</AssemblyVersion>
-    <FileVersion>7.15.61.0</FileVersion>
+    <AssemblyVersion>7.15.62.0</AssemblyVersion>
+    <FileVersion>7.15.62.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sushi.Mediakiwi/Controllers/Data/ContentComponent.cs
+++ b/src/Sushi.Mediakiwi/Controllers/Data/ContentComponent.cs
@@ -2,10 +2,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Sushi.Mediakiwi.Controllers.Data
 {
+    /// <summary>
+    /// Component content
+    /// </summary>
+    [DataContract]
     public class ContentComponent
     {
         public ContentComponent Clone()
@@ -25,26 +30,65 @@ namespace Sushi.Mediakiwi.Controllers.Data
                 clone.Content = new Dictionary<string, ContentItem>();
                 foreach (var key in Content.Keys)
                 {
-                    var source = Content[key];
                     clone.Content.Add(key, Content[key]);
                 }
             }
             return clone;
 
         }
+
         public ContentComponent()
         {
             Content = new Dictionary<string, ContentItem>();
+            Nested = new List<ContentComponent>();
         }
 
+        /// <summary>
+        /// The path (source tag) of the component
+        /// </summary>
+        [DataMember(Name = "componentName")]
         public string ComponentName { get; set; }
+
+        /// <summary>
+        /// The Component ID 
+        /// </summary>
+        [DataMember(Name = "componentId")]
         public int ComponentID { get; set; }
+
+        /// <summary>
+        /// The sortorder for this SortOrder
+        /// </summary>
+        [DataMember(Name = "sortOrder")]
         public int SortOrder { get; set; }
-        public string Title { get; set; }
+
+        /// <summary>
+        /// For which slot is this component relevant
+        /// </summary>
+        [DataMember(Name = "slot")]
         public string Slot { get; set; }
+
+        /// <summary>
+        /// The Dictionary with content for this Component
+        /// </summary>
+        [DataMember(Name = "content")]
         public Dictionary<string, ContentItem> Content { get; set; }
 
+        /// <summary>
+        /// Get the nested Components
+        /// </summary>
+        [DataMember(Name = "nested")]
         public List<ContentComponent> Nested { get; set; }
+
+        /// <summary>
+        /// Is this a shared component ?
+        /// </summary>
+        [DataMember(Name = "isShared")]
         public bool IsShared { get; set; }
+
+        /// <summary>
+        /// What is the component template title (name) ?
+        /// </summary>
+        [DataMember(Name = "title")]
+        public string Title { get; set; }
     }
 }

--- a/src/Sushi.Mediakiwi/Controllers/Data/ContentMetaData.cs
+++ b/src/Sushi.Mediakiwi/Controllers/Data/ContentMetaData.cs
@@ -1,21 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Sushi.Mediakiwi.Controllers.Data
 {
+    /// <summary>
+    /// Page Meta Data class
+    /// </summary>
+    [DataContract]
     public class ContentMetaData
     {
         public ContentMetaData()
         {
-
+            MetaTags = new List<ContentMetaTag>();
         }
 
+        /// <summary>
+        /// The Page Title
+        /// </summary>
+        [DataMember(Name = "pageTitle")]
         public string PageTitle { get; set; }
+
+        /// <summary>
+        /// The Page description
+        /// </summary>
+        [DataMember(Name = "pageDescription")]
         public string PageDescription { get; set; }
+
+        /// <summary>
+        /// The Html Language
+        /// </summary>
+        [DataMember(Name = "htmlLang")]
         public string HtmlLang { get; set; }
+
+        /// <summary>
+        /// The Meta Tags collection
+        /// </summary>
+        [DataMember(Name = "metaTags")]
         public List<ContentMetaTag> MetaTags { get; set; }
+
+        /// <summary>
+        /// Gets a metatag by its Key
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
         public ContentMetaTag this[string key]
         {
             get
@@ -43,6 +73,11 @@ namespace Sushi.Mediakiwi.Controllers.Data
         {
             if (ContainsKey(name) == false)
             {
+                if (MetaTags == null)
+                {
+                    MetaTags = new List<ContentMetaTag>();
+                }
+
                 MetaTags.Add(new ContentMetaTag(name, content, renderKey));
             }
             else if (overWriteIfExists)

--- a/src/Sushi.Mediakiwi/Controllers/Data/ContentMetaTag.cs
+++ b/src/Sushi.Mediakiwi/Controllers/Data/ContentMetaTag.cs
@@ -1,9 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Runtime.Serialization;
 
 namespace Sushi.Mediakiwi.Controllers.Data
 {
+    /// <summary>
+    /// A Single Meta tag
+    /// </summary>
+    [DataContract]
     public class ContentMetaTag
     {
         public ContentMetaTag(string name, string content, MetaTagRenderKey renderKey = MetaTagRenderKey.NAME)
@@ -13,8 +15,22 @@ namespace Sushi.Mediakiwi.Controllers.Data
             RenderKey = renderKey;
         }
 
+        /// <summary>
+        /// Will this metatag render its key as a 'Name' or 'Property' attribute
+        /// </summary>
+        [DataMember(Name = "renderKey")]
         public MetaTagRenderKey RenderKey { get; set; }
+
+        /// <summary>
+        /// The Key (name / property) of this Metatag 
+        /// </summary>
+        [DataMember(Name = "name")]
         public string Name { get; set; }
+
+        /// <summary>
+        /// The value of this Metatag
+        /// </summary>
+        [DataMember(Name = "value")]
         public string Value { get; set; }
     }
 }

--- a/src/Sushi.Mediakiwi/Controllers/Data/InternalInformation.cs
+++ b/src/Sushi.Mediakiwi/Controllers/Data/InternalInformation.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Sushi.Mediakiwi.Controllers.Data
+{
+    /// <summary>
+    /// Strictly for communicating internal information across pages and components
+    /// </summary>
+    [DataContract]
+    public class InternalInformation
+    {
+        /// <summary>
+        /// Is this is a preview call ?
+        /// </summary>
+        [DataMember(Name = "isPreview")]
+        public bool IsPreview { get; set; }
+
+        /// <summary>
+        /// Is this a Cache clear call ?
+        /// </summary>
+        [DataMember(Name = "clearCache")]
+        public bool ClearCache { get; set; }
+
+        /// <summary>
+        /// Add anything you want to communicate 
+        /// </summary>
+        [DataMember(Name = "customData")]
+        public Dictionary<string, object> CustomData { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Adds an item to the CustomData dictionary
+        /// </summary>
+        /// <param name="name">The name for the dictionary item</param>
+        /// <param name="value">The value for the dictionary item</param>
+        /// <param name="overWriteIsExists">When TRUE, overwrite an existing item, else do NOT overwrite an existing item</param>
+        public void Add(string name, object value, bool overWriteIsExists = false)
+        {
+            if (CustomData.ContainsKey(name) == false)
+            {
+                CustomData.Add(name, value);
+            }
+            else if (overWriteIsExists)
+            {
+                CustomData[name] = value;
+            }
+        }
+
+    }
+}

--- a/src/Sushi.Mediakiwi/Controllers/Data/PageContentResponse.cs
+++ b/src/Sushi.Mediakiwi/Controllers/Data/PageContentResponse.cs
@@ -1,10 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Sushi.Mediakiwi.Controllers.Data
 {
+    /// <summary>
+    /// The response from the Content API
+    /// </summary>
+    [DataContract]
     public class PageContentResponse
     {
         public PageContentResponse()
@@ -14,39 +19,52 @@ namespace Sushi.Mediakiwi.Controllers.Data
         }
 
         /// <summary>
-        /// Is there an exception thrown ?
+        /// The PadeID from mediakiwi
         /// </summary>
-        public string Exception { get; set; }
-
-        /// <summary>
-        /// What is the page ID of the page
-        /// </summary>
+        [DataMember(Name = "pageId")]
         public int PageID { get; set; }
 
         /// <summary>
-        /// The Path of the page in the CMS
+        /// The Page Location (path) to the Page template
         /// </summary>
-        public string PageInternalPath { get; set; }
-
-        /// <summary>
-        /// Sets the page location for StatusCode OK,
-        /// or a redirect path for StatusCode NotFound
-        /// </summary>
+        [DataMember(Name = "pageLocation")]
         public string PageLocation { get; set; }
 
         /// <summary>
-        /// All components belonging to this page.
+        /// The Internal path from MediaKiwi
         /// </summary>
-        public List<ContentComponent> Components { get; set; }
+        [DataMember(Name = "pageInternalPath")]
+        public string PageInternalPath { get; set; }
 
         /// <summary>
-        /// All MetaData belonging to this page.
+        /// All page Components
         /// </summary>
-        public ContentMetaData MetaData { get; set; }
+        [DataMember(Name = "components")]
+        public List<ContentComponent> Components { get; set; }
 
         /// <summary>
         /// The Http statuscode for the response
         /// </summary>
+        [DataMember(Name = "statusCode")]
         public HttpStatusCode StatusCode { get; set; }
+
+
+        /// <summary>
+        /// The exception (if any)
+        /// </summary>
+        [DataMember(Name = "exception")]
+        public string Exception { get; set; }
+
+        /// <summary>
+        /// The Metadata for this page
+        /// </summary>
+        [DataMember(Name = "metaData")]
+        public ContentMetaData MetaData { get; set; }
+
+        /// <summary>
+        /// Internal information for this Page (if any)
+        /// </summary>
+        [DataMember(Name = "internalInfo")]
+        public InternalInformation InternalInfo { get; set; } = new InternalInformation();
     }
 }

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.61</Version>
+    <Version>7.15.62</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>
@@ -15,8 +15,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.61.0</AssemblyVersion>
-    <FileVersion>7.15.61.0</FileVersion>
+    <AssemblyVersion>7.15.62.0</AssemblyVersion>
+    <FileVersion>7.15.62.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
This addition will return the need for a Cache Flush from the ContenController to the Mediakiwi Content Service, so that consequent calls will know if they need to request a cache flush.
The need to a cache flush is transferred onto each Component in the _InternalInfo.ClearCache_ property.
So each seperate component knows that a cache flush must be requested when performing an API call
