### PR TITLE
Missing HTTP statuscode for excluded URLs

### DIFF
--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>7.15.69</Version>
+    <Version>7.15.70</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -14,8 +14,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.69.0</AssemblyVersion>
-    <FileVersion>7.15.69.0</FileVersion>
+    <AssemblyVersion>7.15.70.0</AssemblyVersion>
+    <FileVersion>7.15.70.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sushi.Mediakiwi.Headless/MediaKiwiRewriteRule.cs
+++ b/src/Sushi.Mediakiwi.Headless/MediaKiwiRewriteRule.cs
@@ -50,6 +50,11 @@ namespace Sushi.Mediakiwi.Headless
             {
                 _logger.LogError("ContentService IS NULL, skipping the MK Rewrite rule");
             }
+            else if (ContentService.IsPageExcluded(context.HttpContext.Request))
+            {
+                var url = context.HttpContext.Request.GetDisplayUrl();
+                _logger.LogInformation($"This url ({url}) was Excluded from the content service");
+            }
             else
             {
                 var request = context.HttpContext.Request;

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.69</Version>
+    <Version>7.15.70</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>
@@ -11,8 +11,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://mediakiwi.atlassian.net/wiki/spaces/CORE/overview</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Supershift/Sushi.Mediakiwi</RepositoryUrl>
-    <AssemblyVersion>7.15.69.0</AssemblyVersion>
-    <FileVersion>7.15.69.0</FileVersion>
+    <AssemblyVersion>7.15.70.0</AssemblyVersion>
+    <FileVersion>7.15.70.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>7.15.69</Version>
+    <Version>7.15.70</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>
@@ -15,8 +15,8 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
-    <AssemblyVersion>7.15.69.0</AssemblyVersion>
-    <FileVersion>7.15.69.0</FileVersion>
+    <AssemblyVersion>7.15.70.0</AssemblyVersion>
+    <FileVersion>7.15.70.0</FileVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
This issue was resolved by:

- Moving up the check if a requested URL should be going through the ContentService.
- When this check fails (so the URL should be excluded), the rule is skipped, so no ContentService is hit
- This results in the request firing uninterrupted, returning a valid HttpStatusCode