### PR TITLE
Bug/root access rules check

### DIFF
--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>
+    <Version>8.1.5</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>
+    <Version>8.1.5</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Data/ApplicationRole.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ApplicationRole.cs
@@ -266,7 +266,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             return connector.FetchAll(filter).ToArray<IApplicationRole>();
         }
@@ -279,7 +279,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             return result.ToArray<IApplicationRole>();
@@ -294,7 +294,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderID", folderID);
 
             return connector.FetchAll(
@@ -313,7 +313,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderID", folderID);
 
             var result = await connector.FetchAllAsync(

--- a/src/Sushi.Mediakiwi.Data/Data/ApplicationUser.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ApplicationUser.cs
@@ -388,7 +388,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneAsync(int ID, bool onlyReturnActive = false)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ID, ID);
             if (onlyReturnActive)
@@ -406,7 +406,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOne(string email, bool onlyReturnActive = false)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.Email, email);
             if (onlyReturnActive)
@@ -423,7 +423,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOne(int ID, bool onlyReturnActive = false)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ID, ID);
             if (onlyReturnActive)
@@ -440,7 +440,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOne(string username)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             
             return connector.FetchSingle(filter);
@@ -453,7 +453,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneAsync(string username)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -467,7 +467,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOne(string username, int? ignoreApplicationUserID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             if (ignoreApplicationUserID.HasValue)
             {
@@ -484,7 +484,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneAsync(string username, int? ignoreApplicationUserID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             if (ignoreApplicationUserID.HasValue)
             {
@@ -500,7 +500,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOneByEmail(string email)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Email, email);
             
             return connector.FetchSingle(filter);
@@ -513,7 +513,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneByEmailAsync(string email)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Email, email);
             
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -526,7 +526,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOneByEmail(string email, int? ignoreApplicationUserID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Email, email);
             if (ignoreApplicationUserID.HasValue)
             {
@@ -542,7 +542,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneByEmailAsync(string email, int? ignoreApplicationUserID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Email, email);
             if (ignoreApplicationUserID.HasValue)
             {
@@ -558,7 +558,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser SelectOne(Guid applicationUserGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, applicationUserGUID);
             
             return connector.FetchSingle(filter);
@@ -571,7 +571,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser> SelectOneAsync(Guid applicationUserGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, applicationUserGUID);
             
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -589,7 +589,7 @@ namespace Sushi.Mediakiwi.Data
                 return new ApplicationUser();
 
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             filter.Add(x => x.Password, password);
             
@@ -609,7 +609,7 @@ namespace Sushi.Mediakiwi.Data
                 return new ApplicationUser();
             }
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, username);
             filter.Add(x => x.Password, password);
             
@@ -622,7 +622,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             return connector.FetchAll(filter).ToArray();
         }
@@ -633,7 +633,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             
             return result.ToArray();
@@ -647,7 +647,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser[] SelectAll(string username, int role)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (!string.IsNullOrWhiteSpace(username))
             {
@@ -668,7 +668,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser[]> SelectAllAsync(string username, int role)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (!string.IsNullOrWhiteSpace(username))
             {
@@ -689,7 +689,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser[] SelectAll(int? role)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (role.HasValue)
             {
                 filter.Add(x => x.RoleID, role.Value);
@@ -704,7 +704,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser[]> SelectAllAsync(int? role)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (role.HasValue)
             {
                 filter.Add(x => x.RoleID, role.Value);
@@ -722,7 +722,7 @@ namespace Sushi.Mediakiwi.Data
         public static IApplicationUser[] SelectAll(int? role, bool onlyReturnActive)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (role.HasValue)
             {
                 filter.Add(x => x.RoleID, role.Value);
@@ -743,7 +743,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IApplicationUser[]> SelectAllAsync(int? role, bool onlyReturnActive)
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (role.HasValue)
             {
                 filter.Add(x => x.RoleID, role.Value);

--- a/src/Sushi.Mediakiwi.Data/Data/Article.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Article.cs
@@ -112,7 +112,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<ArticleList> SelectList(int listID)
         {
             var connector = ConnectorFactory.CreateConnector<ArticleList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@listId", listID);
 
@@ -133,7 +133,7 @@ SELECT [Wiki_Key]
         public static async Task<List<ArticleList>> SelectListAsync(int listID)
         {
             var connector = ConnectorFactory.CreateConnector<ArticleList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@listId", listID);
 
@@ -154,7 +154,7 @@ SELECT [Wiki_Key]
             try
             {
                 var connector = ConnectorFactory.CreateConnector<Article>();
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
 
                 if (wikiList.HasValue) 
                     filter.Add(x => x.BelongsToListID, wikiList.Value);
@@ -177,7 +177,7 @@ SELECT [Wiki_Key]
             try
             {
                 var connector = ConnectorFactory.CreateConnector<Article>();
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
 
                 if (wikiList.HasValue)
                     filter.Add(x => x.BelongsToListID, wikiList.Value);
@@ -198,7 +198,7 @@ SELECT [Wiki_Key]
         public static Article SelectOneForListOrNew(int forListID, string defaultTitle)
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.BelongsToListID, forListID);
             var item = connector.FetchSingle(filter);
             if (item == null || item.ID < 1)
@@ -211,7 +211,7 @@ SELECT [Wiki_Key]
         public static async Task<Article> SelectOneForListOrNewAsync(int forListID, string defaultTitle)
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.BelongsToListID, forListID);
             var item = await connector.FetchSingleAsync(filter).ConfigureAwait(false);
             if (item == null || item.ID < 1)
@@ -262,7 +262,7 @@ SELECT [Wiki_Key]
         public static Article SelectOneForPageOrNew(int forPageID, string defaultTitle)
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.BelongsToPageID, forPageID);
 
             var item = connector.FetchSingle(filter);
@@ -275,7 +275,7 @@ SELECT [Wiki_Key]
         public static async Task<Article> SelectOneForPageOrNewAsync(int forPageID, string defaultTitle)
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.BelongsToPageID, forPageID);
 
             var item = await connector.FetchSingleAsync(filter).ConfigureAwait(false);

--- a/src/Sushi.Mediakiwi.Data/Data/Asset.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Asset.cs
@@ -370,7 +370,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Asset> SelectAll_Local()
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RemoteLocation, null);
             filter.Add(x => x.ParentID, null);
 
@@ -380,7 +380,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Asset> SelectAll_Variant(int parentID, string relativeGalleryPath = null)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, parentID);
 
             return connector.FetchAll(filter);
@@ -389,7 +389,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Asset>> SelectAll_VariantAsync(int parentID, string relativeGalleryPath = null)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, parentID);
 
             return await connector.FetchAllAsync(filter).ConfigureAwait(false);
@@ -399,7 +399,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Asset> SelectRange(int[] items)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             int i = 0;
             var sql_in = new List<string>();
@@ -424,7 +424,7 @@ where
         public static async Task<List<Asset>> SelectRangeAsync(int[] items)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             int i = 0;
             var sql_in = new List<string>();
@@ -449,7 +449,7 @@ where
         public static List<Asset> SelectAll(int galleryID, int? assetTypeID = null, bool onlyReturnActiveAssets = false, bool onlyReturnDocuments = false, bool onlyReturnImages = false)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GalleryID, galleryID);
             filter.Add(x => x.ParentID, null);
 
@@ -478,7 +478,7 @@ where
         public static async Task<List<Asset>> SelectAllAsync(int galleryID, int? assetTypeID = null, bool onlyReturnActiveAssets = false, bool onlyReturnDocuments = false, bool onlyReturnImages = false)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GalleryID, galleryID);
             filter.Add(x => x.ParentID, null);
             
@@ -507,7 +507,7 @@ where
         public static List<Asset> SearchAll(string searchCandidate, int? galleryID = null, bool onlyReturnActiveAssets = false)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, null);
 
             if (!string.IsNullOrWhiteSpace(searchCandidate))
@@ -530,7 +530,7 @@ where
         public static async Task<List<Asset>> SearchAllAsync(string searchCandidate, int? galleryID = null, bool onlyReturnActiveAssets = false, bool onlyReturnDocuments = false, bool onlyReturnImages = false)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, null);
 
             if (!string.IsNullOrWhiteSpace(searchCandidate))
@@ -566,7 +566,7 @@ where
         public static async Task<List<Asset>> SelectAll_LocalAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RemoteLocation, null);
             filter.Add(x => x.ParentID, null);
 
@@ -588,7 +588,7 @@ where
         public static Asset SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return connector.FetchSingle(filter);
         }
@@ -596,7 +596,7 @@ where
         public static async Task<Asset> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return await connector.FetchSingleAsync(filter);
         }
@@ -604,7 +604,7 @@ where
         public static Asset SelectOne(int galleryID, int assetTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.AssetTypeID, assetTypeID);
             filter.Add(x => x.GalleryID, galleryID);
             
@@ -614,7 +614,7 @@ where
         public static async Task<Asset> SelectOneAsync(int galleryID, int assetTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.AssetTypeID, assetTypeID);
             filter.Add(x => x.GalleryID, galleryID);
 
@@ -627,7 +627,7 @@ where
         internal static bool DeleteInactive()
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsActive, false);
             connector.Delete(filter);
             return true;

--- a/src/Sushi.Mediakiwi.Data/Data/AssetType.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/AssetType.cs
@@ -75,7 +75,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAssetType SelectOne(string Tag)
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Tag, Tag);
             return connector.FetchSingle(filter);
         }
@@ -87,7 +87,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAssetType> SelectOneAsync(string Tag)
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Tag, Tag);
             return await connector.FetchSingleAsync(filter);
         }
@@ -99,7 +99,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAssetType[] SelectAll(bool onlyReturnVariant = false)
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (onlyReturnVariant)
                 filter.Add(x => x.IsVariant, true);
             filter.AddOrder(x => x.Name);
@@ -113,7 +113,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAssetType[]> SelectAllAsync(bool onlyReturnVariant = false)
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (onlyReturnVariant)
                 filter.Add(x => x.IsVariant, true);
             filter.AddOrder(x => x.Name);

--- a/src/Sushi.Mediakiwi.Data/Data/AuditTrail.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/AuditTrail.cs
@@ -114,7 +114,7 @@ namespace Sushi.Mediakiwi.Data
         public static AuditTrail[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<AuditTrail>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID, SortOrder.DESC);
             return connector.FetchAll(filter).ToArray();
         }
@@ -125,7 +125,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<AuditTrail[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<AuditTrail>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID, SortOrder.DESC);
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();

--- a/src/Sushi.Mediakiwi.Data/Data/AvailableTemplate.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/AvailableTemplate.cs
@@ -174,7 +174,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate SelectOne(int pageTemplateID, string fixedTag)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             filter.Add(x => x.FixedFieldName, fixedTag);
             return connector.FetchSingle(filter);
@@ -189,7 +189,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAvailableTemplate> SelectOneAsync(int pageTemplateID, string fixedTag)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             filter.Add(x => x.FixedFieldName, fixedTag);
             return await connector.FetchSingleAsync(filter);
@@ -202,7 +202,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             return connector.FetchAll(filter).ToArray();
         }
@@ -214,7 +214,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAvailableTemplate[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();
@@ -228,7 +228,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate[] SelectAll(int pageTemplateID, string target = null)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             if (!string.IsNullOrEmpty(target))
                 filter.Add(x => x.Target, target);
@@ -245,7 +245,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAvailableTemplate[]> SelectAllAsync(int pageTemplateID, string target = null)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             if (!string.IsNullOrEmpty(target))
                 filter.Add(x => x.Target, target);
@@ -257,7 +257,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate[] SelectAllByComponentTemplate(int componentTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ComponentTemplateID, componentTemplateID);
             filter.AddOrder(x => x.SortOrder);
             var result = connector.FetchAll(filter);
@@ -267,7 +267,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate[] SelectAllBySlot(int slotID)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SlotID, slotID);
             filter.AddOrder(x => x.SortOrder);
             var result = connector.FetchAll(filter);
@@ -276,7 +276,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAvailableTemplate[]> SelectAllBySlotAsync(int slotID)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SlotID, slotID);
             filter.AddOrder(x => x.SortOrder);
             var result = await connector.FetchAllAsync(filter);
@@ -286,7 +286,7 @@ namespace Sushi.Mediakiwi.Data
         public static IAvailableTemplate[] SelectAllBySlSelectAllByComponentTemplate(int templateID)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ComponentTemplateID, templateID);
             filter.AddOrder(x => x.SortOrder);
             var result = connector.FetchAll(filter);
@@ -295,7 +295,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IAvailableTemplate[]> SelectAllByComponentTemplateAsync(int templateID)
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ComponentTemplateID, templateID);
             filter.AddOrder(x => x.SortOrder);
             var result = await connector.FetchAllAsync(filter);
@@ -313,7 +313,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageTemplateID", pageTemplateID);
             filter.AddParameter("@pageID", pageID);
 
@@ -348,7 +348,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageTemplateID", pageTemplateID);
             filter.AddParameter("@pageID", pageID);
 
@@ -422,7 +422,7 @@ namespace Sushi.Mediakiwi.Data
             //}
 
             var connector = ConnectorFactory.CreateConnector(new AvailableTemplateMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             connector.Delete(filter);
         }
@@ -436,7 +436,7 @@ namespace Sushi.Mediakiwi.Data
         public static void Delete(int pageTemplateID, bool isSecundary, string target)
         {
             var connector = ConnectorFactory.CreateConnector(new AvailableTemplateMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             filter.Add(x => x.IsSecundary, isSecundary);
 
@@ -461,7 +461,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task DeleteAsync(int pageTemplateID, bool isSecundary, string target)
         {
             var connector = ConnectorFactory.CreateConnector(new AvailableTemplateMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageTemplateID, pageTemplateID);
             filter.Add(x => x.IsSecundary, isSecundary);
 

--- a/src/Sushi.Mediakiwi.Data/Data/CacheItem.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/CacheItem.cs
@@ -88,7 +88,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICacheItem[] SelectAll(DateTime dt)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Created, dt, ComparisonOperator.GreaterThan);
             return connector.FetchAll(filter).ToArray();
         }
@@ -111,7 +111,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICacheItem[]> SelectAllAsync(DateTime dt)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Created, dt, ComparisonOperator.GreaterThan);
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();

--- a/src/Sushi.Mediakiwi.Data/Data/Component.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Component.cs
@@ -119,7 +119,7 @@ namespace Sushi.Mediakiwi.Data
         public static Component[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             return connector.FetchAll(filter).ToArray();
@@ -131,7 +131,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Component[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
@@ -168,7 +168,7 @@ namespace Sushi.Mediakiwi.Data
         public static Component SelectOne(Guid componentGUID)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentGUID);
 
             return connector.FetchSingle(filter);
@@ -182,7 +182,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Component> SelectOneAsync(Guid componentGUID)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentGUID);
 
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -197,7 +197,7 @@ namespace Sushi.Mediakiwi.Data
         public static Component SelectOne(int pageID, string fixedComponentId)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FixedId, fixedComponentId);
             filter.Add(x => x.IsFixedOnTemplate, true);
             filter.Add(x => x.PageID, pageID);
@@ -214,7 +214,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Component> SelectOneAsync(int pageID, string componentID)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FixedId, componentID);
             filter.Add(x => x.IsFixedOnTemplate, true);
             filter.Add(x => x.PageID, pageID);
@@ -232,7 +232,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MR:07-01-2020] CHECK if this query works
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             filter.Add("[ComponentTemplate_Type]", SqlDbType.NVarChar, type.BaseType.ToString());
 
@@ -249,7 +249,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MR:07-01-2020] CHECK if this query works
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             filter.Add("[ComponentTemplate_Type]", SqlDbType.NVarChar, type.BaseType.ToString());
 
@@ -265,7 +265,7 @@ namespace Sushi.Mediakiwi.Data
         public static Component[] SelectAll(int pageID, int componentTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ComponentTemplateID, componentTemplateID);
             filter.Add(x => x.PageID, pageID);
@@ -282,7 +282,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Component[]> SelectAllAsync(int pageID, int componentTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ComponentTemplateID, componentTemplateID);
             filter.Add(x => x.PageID, pageID);
@@ -300,7 +300,7 @@ namespace Sushi.Mediakiwi.Data
         public static Component[] SelectAll(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             if (isSecundary)
@@ -326,7 +326,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Component[]> SelectAllAsync(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             if (isSecundary)
@@ -471,7 +471,7 @@ namespace Sushi.Mediakiwi.Data
                 pageID = page.MasterID.Value;
             }
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             
             var result = connector.FetchAll(filter);
@@ -498,7 +498,7 @@ namespace Sushi.Mediakiwi.Data
                 pageID = page.MasterID.Value;
             }
             
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
             filter.AddParameter("@isShared", true);
 
@@ -546,7 +546,7 @@ namespace Sushi.Mediakiwi.Data
                 pageID = page.MasterID.Value;
             }
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             filter.AddOrder(x => x.SortOrder, Sushi.MicroORM.SortOrder.ASC);
 
@@ -574,7 +574,7 @@ namespace Sushi.Mediakiwi.Data
                 pageID = page.MasterID.Value;
             }
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
             filter.AddParameter("@isShared", true);
 

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentList.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentList.cs
@@ -616,7 +616,7 @@ namespace Sushi.Mediakiwi.Data
         public static bool UpdateSortOrder(int listID, int sortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@sortOrder", sortOrder);
             filter.AddParameter("@listId", listID);
@@ -635,7 +635,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<bool> UpdateSortOrderAsync(int listID, int sortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@sortOrder", sortOrder);
             filter.AddParameter("@listId", listID);
@@ -653,7 +653,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -668,7 +668,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -685,7 +685,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList[] SelectAllBySite(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
@@ -702,7 +702,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList[]> SelectAllBySiteAsync(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
@@ -721,7 +721,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList[] SelectAll(string text, int? siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -752,7 +752,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList[]> SelectAllAsync(string text, int? siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -784,7 +784,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList[] SelectAll(int folderID, bool includeHidden = false)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -803,7 +803,7 @@ namespace Sushi.Mediakiwi.Data
                 if (!folder.MasterID.HasValue)
                     break;
 
-                filter = connector.CreateDataFilter();
+                filter = connector.CreateQuery();
                 filter.Add(x => x.FolderID, folder.MasterID.Value);
                 filter.Add(x => x.IsInherited, true);
                 filter.AddOrder(x => x.SortOrder);
@@ -833,7 +833,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList[]> SelectAllAsync(int folderID, bool includeHidden = false)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.AddOrder(x => x.ReferenceID);
             filter.AddOrder(x => x.Name);
@@ -853,7 +853,7 @@ namespace Sushi.Mediakiwi.Data
                 if (!folder.MasterID.HasValue)
                     break;
 
-                filter = connector.CreateDataFilter();
+                filter = connector.CreateQuery();
                 filter.Add(x => x.FolderID, folder.MasterID.Value);
                 filter.Add(x => x.IsInherited, true);
                 filter.AddOrder(x => x.SortOrder);
@@ -1120,7 +1120,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList SelectOne(ComponentListType type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Type, type);
 
             return connector.FetchSingle(filter);
@@ -1134,7 +1134,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList> SelectOneAsync(ComponentListType type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Type, type);
 
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -1148,7 +1148,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList SelectOne(string className)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ClassName, className);
 
             return connector.FetchSingle(filter);
@@ -1161,7 +1161,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList SelectOne(string name, int? folder)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, name);
 
             if (folder.HasValue)
@@ -1179,7 +1179,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList> SelectOneAsync(string name, int? folder)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, name);
 
             if (folder.HasValue)
@@ -1198,7 +1198,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList> SelectOneAsync(string className)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ClassName, className);
 
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -1232,7 +1232,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList SelectOneByReference(int referenceID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceID);
 
             return connector.FetchSingle(filter);
@@ -1246,7 +1246,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList> SelectOneByReferenceAsync(int referenceID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceID);
 
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
@@ -1260,7 +1260,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentList SelectOne(Guid componentListGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentListGUID);
 
             return connector.FetchSingle(filter);
@@ -1274,7 +1274,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentList> SelectOneAsync(Guid componentListGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentListGUID);
 
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentListVersion.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentListVersion.cs
@@ -167,7 +167,7 @@ namespace Sushi.Mediakiwi.Data
                 return new ComponentListVersion();
 
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             filter.MaxResults = 1;
             filter.AddOrder(x => x.ID, SortOrder.DESC);
@@ -191,7 +191,7 @@ namespace Sushi.Mediakiwi.Data
                 return new ComponentListVersion();
 
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             filter.MaxResults = 1;
             filter.AddOrder(x => x.ID, SortOrder.DESC);
@@ -211,7 +211,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentListVersion SelectOne(int siteID, int componentListID, int componentListVersionItemID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             filter.MaxResults = 1;
             filter.AddOrder(x => x.ID, SortOrder.DESC);
@@ -232,7 +232,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentListVersion> SelectOneAsync(int siteID, int componentListID, int componentListVersionItemID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             filter.MaxResults = 1;
             filter.AddOrder(x => x.ID, SortOrder.DESC);
@@ -252,7 +252,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentListVersion[] SelectAll(int componentListID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID, SortOrder.DESC);
             filter.AddParameter("@siteId", siteID);
 
@@ -276,7 +276,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentListVersion[]> SelectAllAsync(int componentListID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID, SortOrder.DESC);
             filter.AddParameter("@siteId", siteID);
 
@@ -300,7 +300,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentListVersion SelectOne(Guid componentListVersionGUID, int siteID)      
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddSql("EXISTS (SELECT * FROM wim_ComponentLists WHERE ComponentListVersion_ComponentList_Key = ComponentList_Key AND ComponentList_GUID = @componentListGUID)");
             filter.AddParameter("@componentListGUID", componentListVersionGUID);
             filter.Add(x => x.SiteID, siteID);
@@ -317,7 +317,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentListVersion> SelectOneAsync(Guid componentListVersionGUID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddSql("EXISTS (SELECT * FROM wim_ComponentLists WHERE ComponentListVersion_ComponentList_Key = ComponentList_Key AND ComponentList_GUID = @componentListGUID)");
             filter.AddParameter("@componentListGUID", componentListVersionGUID);
             filter.Add(x => x.SiteID, siteID);
@@ -336,7 +336,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentListVersion SelectOneByTemplate(int componentTemplateID, int componentListVersionItemID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddSql("EXISTS (SELECT * FROM wim_ComponentLists WHERE ComponentListVersion_ComponentList_Key = ComponentList_Key AND ComponentList_ComponentTemplate_Key = @componentTemplateID)");
             filter.AddParameter("@componentTemplateID", componentTemplateID);            
             filter.Add(x => x.ComponentListItemID, componentListVersionItemID);
@@ -355,7 +355,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentListVersion> SelectOneByTemplateAsync(int componentTemplateID, int componentListVersionItemID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddSql("EXISTS (SELECT * FROM wim_ComponentLists WHERE ComponentListVersion_ComponentList_Key = ComponentList_Key AND ComponentList_ComponentTemplate_Key = @componentTemplateID)");
             filter.AddParameter("@componentTemplateID", componentTemplateID);
             filter.Add(x => x.ComponentListItemID, componentListVersionItemID);
@@ -370,7 +370,7 @@ namespace Sushi.Mediakiwi.Data
         public bool Save()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@siteId", SiteID);
             filter.AddParameter("@componentListId", ComponentListID);
             filter.AddParameter("@componentListItemId", ComponentListItemID);
@@ -406,7 +406,7 @@ namespace Sushi.Mediakiwi.Data
         public async Task<bool> SaveAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@siteId", SiteID);
             filter.AddParameter("@componentListId", ComponentListID);
             filter.AddParameter("@componentListItemId", ComponentListItemID);

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentTarget.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentTarget.cs
@@ -81,7 +81,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentTarget[] SelectAll(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             return connector.FetchAll(filter).ToArray();
@@ -95,7 +95,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentTarget[]> SelectAllAsync(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -109,7 +109,7 @@ namespace Sushi.Mediakiwi.Data
         public virtual void DeleteComplete()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisTarget", Target);
             filter.AddParameter("@thisSource", Source);
             filter.AddParameter("@thisPageId", PageID);
@@ -129,7 +129,7 @@ AND NOT [ComponentTarget_Component_Source] = @thisSource", filter);
         public async virtual Task DeleteCompleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisTarget", Target);
             filter.AddParameter("@thisSource", Source);
             filter.AddParameter("@thisPageId", PageID);
@@ -150,7 +150,7 @@ AND NOT [ComponentTarget_Component_Source] = @thisSource", filter);
         public static IComponentTarget[] SelectAll(Guid componentGuid)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Source, componentGuid);
 
             return connector.FetchAll(filter).ToArray();
@@ -164,7 +164,7 @@ AND NOT [ComponentTarget_Component_Source] = @thisSource", filter);
         public static async Task<IComponentTarget[]> SelectAllAsync(Guid componentGuid)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Source, componentGuid);
 
             var result = await connector.FetchAllAsync(filter);

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentTargetPage.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentTargetPage.cs
@@ -30,7 +30,7 @@ namespace Sushi.Mediakiwi.Data
         public static IComponentTargetPage[] SelectAll(int templateID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTargetPage>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@templateId", templateID);
             filter.AddParameter("@siteId", siteID);
 
@@ -70,7 +70,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IComponentTargetPage[]> SelectAllAsync(int templateID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTargetPage>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@templateId", templateID);
             filter.AddParameter("@siteId", siteID);
 

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentTemplate.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentTemplate.cs
@@ -269,7 +269,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate SelectOne(Guid componentTemplateGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentTemplateGUID);
             return connector.FetchSingle(filter);
         }
@@ -281,7 +281,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate> SelectOneAsync(Guid componentTemplateGUID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, componentTemplateGUID);
             return await connector.FetchSingleAsync(filter);
         }
@@ -294,7 +294,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate SelectOneByReference(int referenceId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceId);
             return connector.FetchSingle(filter);
         }
@@ -307,7 +307,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate> SelectOneByReferenceAsync(int referenceId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceId);
             return await connector.FetchSingleAsync(filter);
         }
@@ -315,7 +315,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate SelectOneBySourceTag(string sourceTag)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SourceTag, sourceTag);
             return connector.FetchSingle(filter);
         }
@@ -323,7 +323,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate> SelectOneBySourceTagAsync(string sourceTag)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SourceTag, sourceTag);
             return await connector.FetchSingleAsync(filter);
         }
@@ -334,7 +334,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate SelectOne_BasedOnType(Type type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TypeDefinition, type.ToString());
             return connector.FetchSingle(filter);
         }
@@ -342,7 +342,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate> SelectOne_BasedOnTypeAsync(Type type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TypeDefinition, type.ToString());
             return await connector.FetchSingleAsync(filter);
         }
@@ -353,7 +353,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter).ToArray();
         }
 
@@ -363,7 +363,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();
         }
@@ -387,7 +387,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<ComponentTemplate> SearchAll(string searchText, int? siteId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (siteId.GetValueOrDefault(0) > 0)
             {
                 filter.Add(x => x.SiteID, siteId.Value);
@@ -419,7 +419,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<ComponentTemplate>> SearchAllAsync(string searchText, int? siteId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (siteId.GetValueOrDefault(0) > 0)
             {
                 filter.Add(x => x.SiteID, siteId.Value);
@@ -571,7 +571,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.AddParameter("@pageTemplateID", pageTemplateID);
             filter.AddParameter("@pageID", pageID);
@@ -596,7 +596,7 @@ namespace Sushi.Mediakiwi.Data
         {
             //[MJ:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.AddParameter("@pageTemplateID", pageTemplateID);
             filter.AddParameter("@pageID", pageID);
@@ -616,7 +616,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentTemplate[] SelectAllShared()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsShared, true);
             return connector.FetchAll(filter).ToArray();
         }
@@ -627,7 +627,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentTemplate[]> SelectAllSharedAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsShared, true);
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();
@@ -659,7 +659,7 @@ namespace Sushi.Mediakiwi.Data
         public void Delete()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@componentTemplateID", this.ID);
             connector.ExecuteNonQuery(
                 @"DELETE FROM [wim_ComponentSearch] WHERE [ComponentSearch_Ref_Key] = @componentTemplateID
@@ -680,7 +680,7 @@ namespace Sushi.Mediakiwi.Data
         public async Task DeleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@componentTemplateID", this.ID);
             await connector.ExecuteNonQueryAsync(
                 @"DELETE FROM [wim_ComponentSearch] WHERE [ComponentSearch_Ref_Key] = @componentTemplateID

--- a/src/Sushi.Mediakiwi.Data/Data/ComponentVersion.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/ComponentVersion.cs
@@ -272,7 +272,7 @@ namespace Sushi.Mediakiwi.Data
         internal static void RemoveInvalidPageReference(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
 
             connector.ExecuteNonQuery(@"
@@ -295,7 +295,7 @@ namespace Sushi.Mediakiwi.Data
         internal static async Task RemoveInvalidPageReferenceAsync(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
 
             await connector.ExecuteNonQueryAsync(@"
@@ -319,7 +319,7 @@ namespace Sushi.Mediakiwi.Data
         internal static void UpdateContainerTargetByAvailableTemplate(int availableTemplateID, string target)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@templateId", availableTemplateID);
 
             if (string.IsNullOrEmpty(target))
@@ -342,7 +342,7 @@ namespace Sushi.Mediakiwi.Data
         internal static async Task UpdateContainerTargetByAvailableTemplateAsync(int availableTemplateID, string target)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@templateId", availableTemplateID);
 
             if (string.IsNullOrEmpty(target))
@@ -365,7 +365,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICollection<ComponentVersion>> SelectAllForTemplateAsync(int componentTemplateId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.TemplateID, componentTemplateId);
 
@@ -381,7 +381,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<ComponentVersion> SelectAllForTemplate(int componentTemplateId)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.TemplateID, componentTemplateId);
 
@@ -397,7 +397,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             return connector.FetchAll(filter).ToArray();
@@ -410,7 +410,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             var result = await connector.FetchAllAsync(filter);
@@ -425,7 +425,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAll(int pageID, string target = null)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
 
@@ -443,7 +443,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllAsync(int pageID, string target = null)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
 
@@ -462,7 +462,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAllSharedForSite(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, null);
             filter.Add(x => x.TemplateIsShared, true);
@@ -479,7 +479,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllSharedForSiteAsync(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, null);
             filter.Add(x => x.TemplateIsShared, true);
@@ -498,7 +498,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAll(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsSecundary, isSecundary);
@@ -515,7 +515,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllAsync(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsSecundary, isSecundary);
@@ -609,7 +609,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion SelectOneBasedOnType(int pageID, Type type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             filter.Add("[ComponentTemplate_Type]", System.Data.SqlDbType.NVarChar, type.BaseType.ToString());
 
@@ -625,7 +625,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion> SelectOneBasedOnTypeAsync(int pageID, Type type)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
             filter.Add("[ComponentTemplate_Type]", System.Data.SqlDbType.NVarChar, type.BaseType.ToString());
 
@@ -641,7 +641,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion SelectOneFixed(int pageID, string componentversionFixedName)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FixedFieldName, componentversionFixedName);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsFixed, true);
@@ -658,7 +658,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion> SelectOneFixedAsync(int pageID, string componentversionFixedName)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FixedFieldName, componentversionFixedName);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsFixed, true);
@@ -698,7 +698,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return connector.FetchSingle(filter);
@@ -712,7 +712,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return await connector.FetchSingleAsync(filter);
@@ -726,7 +726,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion SelectOneShared(int componentTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, null);
             filter.Add(x => x.TemplateID, componentTemplateID);
 
@@ -741,7 +741,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion> SelectOneSharedAsync(int componentTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, null);
             filter.Add(x => x.TemplateID, componentTemplateID);
 
@@ -756,7 +756,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAllOnPage(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsAlive, true);
@@ -772,7 +772,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllOnPageAsync(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsAlive, true);
@@ -789,7 +789,7 @@ namespace Sushi.Mediakiwi.Data
         public static bool DeleteAllOnPage(int pageKey)
         {
             var connector = ConnectorFactory.CreateConnector(new ComponentVersionMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageKey);
 
             try
@@ -812,7 +812,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<bool> DeleteAllOnPageAsync(int pageKey)
         {
             var connector = ConnectorFactory.CreateConnector(new ComponentVersionMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageKey);
 
             try
@@ -836,7 +836,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAllOnPage(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsSecundary, isSecundary);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsAlive, true);
@@ -853,7 +853,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllOnPageAsync(int pageID, bool isSecundary)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsSecundary, isSecundary);
             filter.Add(x => x.PageID, pageID);
             filter.Add(x => x.IsAlive, true);
@@ -873,7 +873,7 @@ namespace Sushi.Mediakiwi.Data
         public static ComponentVersion[] SelectAllFixed(int pageID, bool setAliveTemporaryOff)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsFixed, true);
             filter.Add(x => x.PageID, pageID);
 
@@ -900,7 +900,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ComponentVersion[]> SelectAllFixedAsync(int pageID, bool setAliveTemporaryOff)
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsFixed, true);
             filter.Add(x => x.PageID, pageID);
 
@@ -953,7 +953,7 @@ namespace Sushi.Mediakiwi.Data
             if (page.InheritContent && page.MasterID.HasValue)
                 pageID = page.MasterID.Value;
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
             filter.AddParameter("@isShared", true);
 
@@ -1003,7 +1003,7 @@ namespace Sushi.Mediakiwi.Data
             if (page.InheritContent && page.MasterID.HasValue)
                 pageID = page.MasterID.Value;
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageID);
             filter.AddParameter("@isShared", true);
 

--- a/src/Sushi.Mediakiwi.Data/Data/Country.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Country.cs
@@ -94,7 +94,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICountry SelectOne(Guid countryGUID)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, countryGUID);
             return connector.FetchSingle(filter);
         }
@@ -107,7 +107,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICountry> SelectOneAsync(Guid countryGUID)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, countryGUID);
             return await connector.FetchSingleAsync(filter);
         }
@@ -120,7 +120,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICountry SelectOne(string englishName)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Country_EN, englishName);
             return connector.FetchSingle(filter);
         }
@@ -133,7 +133,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICountry> SelectOneAsync(string englishName)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Country_EN, englishName);
             return await connector.FetchSingleAsync(filter);
         }
@@ -144,7 +144,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICountry[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter).ToArray();
         }
 
@@ -154,7 +154,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICountry[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var aresult = await connector.FetchAllAsync(filter);
             return aresult.ToArray();
         }
@@ -167,7 +167,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICountry[] SelectAll(string languageSortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (languageSortOrder.Equals("nl", StringComparison.CurrentCultureIgnoreCase))
                 return connector.FetchAll(filter).OrderBy(x => x.Country_NL).ToArray();
@@ -182,7 +182,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICountry[]> SelectAllAsync(string languageSortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var aresult = await connector.FetchAllAsync(filter);
 
@@ -200,7 +200,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICountry[] SelectAll(bool onlyReturnActiveCountries, string languageSortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (onlyReturnActiveCountries)
                 filter.Add(x => x.IsActive, true);
@@ -219,7 +219,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICountry[]> SelectAllAsync(bool onlyReturnActiveCountries, string languageSortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (onlyReturnActiveCountries)
                 filter.Add(x => x.IsActive, true);

--- a/src/Sushi.Mediakiwi.Data/Data/Document.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Document.cs
@@ -70,7 +70,7 @@ namespace Sushi.Mediakiwi.Data
         public static new Document SelectOne(int ID)
         {
             var connector = ConnectorFactory.CreateConnector<Document>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, ID);
             var result = connector.FetchSingle(filter);
 
@@ -85,7 +85,7 @@ namespace Sushi.Mediakiwi.Data
         public static Document SelectOne(Guid GUID)
         {
             var connector = ConnectorFactory.CreateConnector<Document>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, GUID);
 
             return connector.FetchSingle(filter);
@@ -110,7 +110,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Document> SelectOneAsync(Guid GUID)
         {
             var connector = ConnectorFactory.CreateConnector<Document>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, GUID);
 
             return await connector.FetchSingleAsync(filter);
@@ -124,7 +124,7 @@ namespace Sushi.Mediakiwi.Data
         public static Document[] SelectAll(int galleryID)
         {
             var connector = ConnectorFactory.CreateConnector<Document>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, false);
             filter.Add(x => x.ParentID, null);
             filter.Add(x => x.GalleryID, galleryID);
@@ -141,7 +141,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Document[]> SelectAllAsync(int galleryID)
         {
             var connector = ConnectorFactory.CreateConnector<Document>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, false);
             filter.Add(x => x.ParentID, null);
             filter.Add(x => x.GalleryID, galleryID);

--- a/src/Sushi.Mediakiwi.Data/Data/DocumentType.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/DocumentType.cs
@@ -33,7 +33,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<DocumentType>> FetchAllAsync()
         {
             var connector = new Connector<DocumentType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = await connector.FetchAllAsync(filter);
             return result;
         }
@@ -41,7 +41,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<DocumentType> FetchAll()
         {
             var connector = new Connector<DocumentType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = connector.FetchAll(filter);
             return result;
         }

--- a/src/Sushi.Mediakiwi.Data/Data/Environment.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Environment.cs
@@ -45,7 +45,7 @@ namespace Sushi.Mediakiwi.Data
         public static IEnvironment SelectOne()
         {
             var connector = ConnectorFactory.CreateConnector<Environment>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchSingle(filter);
         }
 
@@ -56,7 +56,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IEnvironment> SelectOneAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Environment>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return await connector.FetchSingleAsync(filter).ConfigureAwait(false);
         }
 

--- a/src/Sushi.Mediakiwi.Data/Data/EnvironmentVersion.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/EnvironmentVersion.cs
@@ -51,14 +51,14 @@ namespace Sushi.Mediakiwi.Data
         public static IEnvironmentVersion Select()
         {
             var connector = ConnectorFactory.CreateConnector<EnvironmentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchSingle(filter);
         }
 
         public static async Task<IEnvironmentVersion> SelectAsync()
         {
             var connector = ConnectorFactory.CreateConnector<EnvironmentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return await connector.FetchSingleAsync(filter);
         }
 
@@ -66,7 +66,7 @@ namespace Sushi.Mediakiwi.Data
         {
             var connector = ConnectorFactory.CreateConnector<EnvironmentVersion>();
             var sql = @"UPDATE wim_Environments SET Environment_Update = @update";
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@update", DateTime.UtcNow);
             connector.ExecuteNonQuery(sql, filter);
             return true;
@@ -76,7 +76,7 @@ namespace Sushi.Mediakiwi.Data
         {
             var connector = ConnectorFactory.CreateConnector<EnvironmentVersion>();
             var sql = @"UPDATE wim_Environments SET Environment_Update = @update";
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@update", DateTime.UtcNow);
             await connector.ExecuteNonQueryAsync(sql, filter).ConfigureAwait(false);
             return true;

--- a/src/Sushi.Mediakiwi.Data/Data/Folder.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Folder.cs
@@ -243,7 +243,7 @@ namespace Sushi.Mediakiwi.Data
             get
             {
                 var connector = ConnectorFactory.CreateConnector<Folder>();
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisId", ID);
 
                 return connector.ExecuteScalar<int>(@"
@@ -266,7 +266,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public bool Delete()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
             filter.AddSql("([Folder_Key] = @thisId OR [Folder_Master_Key] = @thisId)");
             try
@@ -287,7 +287,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public async Task<bool> DeleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
             filter.AddSql("([Folder_Key] = @thisId OR [Folder_Master_Key] = @thisId)");
             try
@@ -354,7 +354,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder SelectOne(string path, int site)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.CompletePath, path);
             filter.Add(x => x.SiteID, site);
 
@@ -369,7 +369,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder> SelectOneAsync(string path, int site)
         { 
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.CompletePath, path);
             filter.Add(x => x.SiteID, site);
 
@@ -406,7 +406,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return connector.FetchSingle(filter);
@@ -420,7 +420,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return await connector.FetchSingleAsync(filter);
@@ -435,7 +435,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         {
             //[MR:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@typeId", (int)Type);
             filter.AddParameter("@completePath", CompletePath);
             filter.AddParameter("@newPath", newFolderCompletePath);
@@ -460,7 +460,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         {
             //[MR:03-01-2020] TEST this method !
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@typeId", (int)Type);
             filter.AddParameter("@completePath", CompletePath);
             filter.AddParameter("@newPath", newFolderCompletePath);
@@ -540,7 +540,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
                 siteID = 0;
 
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.Type, type);
             if (siteID > 0)
@@ -561,7 +561,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
                 siteID = 0;
 
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.Type, type);
             if (siteID > 0)
@@ -579,7 +579,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder SelectOne(int masterFolderID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
             filter.Add(x => x.MasterID, masterFolderID);
 
@@ -595,7 +595,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder> SelectOneAsync(int masterFolderID, int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
             filter.Add(x => x.MasterID, masterFolderID);
 
@@ -609,7 +609,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.AddOrder(x => x.Name);
             filter.AddOrder(x => x.CompletePath);
@@ -624,7 +624,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.AddOrder(x => x.Name);
             filter.AddOrder(x => x.CompletePath);
@@ -640,7 +640,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder[] SelectAll(int[] folderIDs)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.AddOrder(x => x.Name);
             filter.AddOrder(x => x.CompletePath);
@@ -656,7 +656,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder[]> SelectAllAsync(int[] folderIDs)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.AddOrder(x => x.Name);
             filter.AddOrder(x => x.CompletePath);
@@ -989,7 +989,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         internal static Folder[] SelectAllForDeletion(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddOrder(x => x.Name, SortOrder.DESC);
             filter.AddOrder(x => x.CompletePath, SortOrder.DESC);
@@ -1006,7 +1006,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         internal static async Task<Folder[]> SelectAllForDeletionAsync(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddOrder(x => x.Name, SortOrder.DESC);
             filter.AddOrder(x => x.CompletePath, SortOrder.DESC);
@@ -1025,7 +1025,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder SelectOne(int parentID, string name)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, parentID);
             filter.Add(x => x.Name, name);
 
@@ -1041,7 +1041,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static async Task<Folder> SelectOneAsync(int parentID, string name)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ParentID, parentID);
             filter.Add(x => x.Name, name);
 
@@ -1240,7 +1240,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         private bool IsFolderAlreadyTaken(int folderID, string folder)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderId", folderID);
             filter.AddParameter("@folderName", folder);
             var count = connector.ExecuteScalar<int>("SELECT COUNT(*) FROM [Wim_folders] WHERE [Folder_Folder_Key] = @folderId AND [Folder_Name] = @folderName", filter);
@@ -1256,7 +1256,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         private async Task<bool> IsFolderAlreadyTakenAsync(int folderID, string folder)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderId", folderID);
             filter.AddParameter("@folderName", folder);
             var count = await connector.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM [Wim_folders] WHERE [Folder_Folder_Key] = @folderId AND [Folder_Name] = @folderName", filter);
@@ -1451,7 +1451,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
             Folder folder = SelectOne(folderID);
 
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, folder.SiteID);
             filter.AddOrder(x => x.ParentID, SortOrder.DESC);
 
@@ -1487,7 +1487,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
             Folder folder = SelectOne(folderID);
 
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, folder.SiteID);
             filter.AddOrder(x => x.ParentID, SortOrder.DESC);
 
@@ -1522,7 +1522,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         public static Folder[] SelectAllUninherited(int masterID, int siteID, int folderType)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderType", folderType);
             filter.AddParameter("@siteId", siteID);
             filter.AddParameter("@masterId", masterID);
@@ -1550,7 +1550,7 @@ FROM [Wim_ComponentLists] WHERE [ComponentList_Folder_Key] in (SELECT [Folder_Ke
         internal static async Task<Folder[]> SelectAllUninheritedAsync(int masterID, int siteID, int folderType)
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderType", folderType);
             filter.AddParameter("@siteId", siteID);
             filter.AddParameter("@masterId", masterID);

--- a/src/Sushi.Mediakiwi.Data/Data/FolderPath.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/FolderPath.cs
@@ -46,7 +46,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<FolderPath> SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<FolderPath>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             return connector.FetchAll(filter);
         }
@@ -58,7 +58,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<FolderPath>> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<FolderPath>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             return await connector.FetchAllAsync(filter);
         }

--- a/src/Sushi.Mediakiwi.Data/Data/Gallery.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Gallery.cs
@@ -290,7 +290,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery SelectOne(int parentID, string gallery)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, gallery);
             filter.Add(x => x.ParentID, parentID);
 
@@ -306,7 +306,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery> SelectOneAsync(int parentID, string gallery)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Name, gallery);
             filter.Add(x => x.ParentID, parentID);
 
@@ -320,7 +320,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.AddSql("ISNULL([Gallery_IsHidden], 0) = 0");
 
@@ -334,7 +334,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.AddSql("ISNULL([Gallery_IsHidden], 0) = 0");
 
@@ -350,7 +350,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SelectAll(string searchCandidate)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.Add(x => x.Name, $"%{searchCandidate}%", ComparisonOperator.Like);
             filter.Add(x => x.IsActive, true);
@@ -366,7 +366,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SelectAllAsync(string searchCandidate)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.Add(x => x.Name, $"%{searchCandidate}%", ComparisonOperator.Like);
             filter.Add(x => x.IsActive, true);
@@ -383,7 +383,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SearchAll_ByPath(string searchPath)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.Add(x => x.CompletePath, $"{searchPath}%", ComparisonOperator.Like);
 
@@ -398,7 +398,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SearchAll_ByPathAsync(string searchPath)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.CompletePath);
             filter.Add(x => x.CompletePath, $"{searchPath}%", ComparisonOperator.Like);
 
@@ -485,7 +485,7 @@ namespace Sushi.Mediakiwi.Data
                 return new Gallery();
 
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.GUID, galleryGUID);
             filter.Add(x => x.IsActive, true);
@@ -496,7 +496,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery SelectOne(string relativePath, bool onlyReturnActive = false)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.CompletePath, relativePath);
             if (onlyReturnActive)
@@ -508,7 +508,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery> SelectOneAsync(string relativePath, bool onlyReturnActive = false)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.CompletePath, relativePath);
             if (onlyReturnActive)
@@ -624,7 +624,7 @@ namespace Sushi.Mediakiwi.Data
                 return new Gallery();
 
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.GUID, galleryGUID);
             filter.Add(x => x.IsActive, true);
@@ -639,7 +639,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery SelectOneRoot()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             filter.Add(x => x.BaseGalleryID, null);
 
@@ -653,7 +653,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery> SelectOneRootAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             filter.Add(x => x.BaseGalleryID, null);
 
@@ -668,7 +668,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery SelectOneRoot(GalleryType type)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             filter.Add(x => x.TypeID, (int)type);
             filter.Add(x => x.IsFixed, true);
@@ -684,7 +684,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery> SelectOneRootAsync(GalleryType type)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             filter.Add(x => x.TypeID, (int)type);
             filter.Add(x => x.IsFixed, true);
@@ -701,7 +701,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SelectAll(GalleryType type, bool returnFolder)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.IsFixed, false);
             filter.Add(x => x.IsActive, true);
@@ -722,7 +722,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SelectAllAsync(GalleryType type, bool returnFolder)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.IsFixed, false);
             filter.Add(x => x.IsActive, true);
@@ -744,7 +744,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SelectAllByParent(int parentID, bool returnHidden)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.Add(x => x.ParentID, parentID);
             filter.Add(x => x.IsActive, true);
@@ -764,7 +764,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SelectAllByParentAsync(int parentID, bool returnHidden)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.Add(x => x.ParentID, parentID);
             filter.Add(x => x.IsActive, true);
@@ -806,7 +806,7 @@ namespace Sushi.Mediakiwi.Data
         public static Gallery[] SelectAllByBase(int baseGalleryID)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.Add(x => x.BaseGalleryID, baseGalleryID);
             filter.Add(x => x.IsActive, true);
@@ -822,7 +822,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Gallery[]> SelectAllByBaseAsync(int baseGalleryID)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.Add(x => x.BaseGalleryID, baseGalleryID);
             filter.Add(x => x.IsActive, true);
@@ -906,7 +906,7 @@ namespace Sushi.Mediakiwi.Data
             get
             {
                 var connector = ConnectorFactory.CreateConnector<Gallery>();
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisId", ID);
 
                 return connector.ExecuteScalar<int>("SELECT (SELECT COUNT(*) FROM [wim_Galleries] WHERE [Gallery_Gallery_Key] = @thisId) + COUNT(*) FROM [wim_Assets] WHERE [Asset_Gallery_Key] = @thisId)", filter);
@@ -916,7 +916,7 @@ namespace Sushi.Mediakiwi.Data
         private bool IsGalleryAlreadyTaken(int galleryID, string gallery)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@galleryId", galleryID);
             filter.AddParameter("@galleryName", gallery);
 
@@ -1135,7 +1135,7 @@ namespace Sushi.Mediakiwi.Data
         public void UpdateCount()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
 
             connector.ExecuteNonQuery($@"
@@ -1153,7 +1153,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         public async Task UpdateCountAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
 
             await connector.ExecuteNonQueryAsync($@"
@@ -1192,7 +1192,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
 
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@completePath", completePath.Replace("'", ""));
 
             connector.ExecuteNonQuery("UPDATE [dbo].[wim_Galleries] SET [Gallery_IsActive] = 0 WHERE [Gallery_CompletePath] LIKE @completePath + '%'", filter);
@@ -1207,7 +1207,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         public static async Task DeactivateAsync(string completePath)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@completePath", completePath.Replace("'", ""));
 
             await connector.ExecuteNonQueryAsync("UPDATE [dbo].[wim_Galleries] SET [Gallery_IsActive] = 0 WHERE [Gallery_CompletePath] LIKE @completePath + '%'", filter);
@@ -1223,7 +1223,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         public bool UpdateChildren(string newFolderCompletePath)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@oldCompletePath", CompletePath.Replace("'", ""));
             filter.AddParameter("@newCompletePath", newFolderCompletePath.Replace("'", ""));
 
@@ -1247,7 +1247,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         public async Task<bool> UpdateChildrenAsync(string newFolderCompletePath)
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@oldCompletePath", CompletePath.Replace("'", "''"));
             filter.AddParameter("@newCompletePath", newFolderCompletePath.Replace("'", "''"));
 
@@ -1271,7 +1271,7 @@ WHERE [Gallery_Key] = @thisId", filter);
         {
 
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@oldCompletePath", CompletePath.Replace("'", ""));         
 
             try

--- a/src/Sushi.Mediakiwi.Data/Data/Image.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Image.cs
@@ -108,7 +108,7 @@ namespace Sushi.Mediakiwi.Data
         public static Image SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return connector.FetchSingle(filter);
@@ -122,7 +122,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Image> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return await connector.FetchSingleAsync(filter);
@@ -156,7 +156,7 @@ namespace Sushi.Mediakiwi.Data
         public static Image[] SelectAll(int galleryID, int? assetTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsActive, true);
             filter.Add(x => x.IsArchived, false);
@@ -175,7 +175,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Image[]> SelectAllAsync(int galleryID, int? assetTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsActive, true);
             filter.Add(x => x.IsArchived, false);
@@ -194,7 +194,7 @@ namespace Sushi.Mediakiwi.Data
         internal static Image[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsArchived, false);
 
@@ -208,7 +208,7 @@ namespace Sushi.Mediakiwi.Data
         internal static async Task<Image[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsArchived, false);
 
@@ -219,7 +219,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Image> SelectRange(List<int> IDs)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsArchived, false);
             filter.Add(x => x.ID, IDs, ComparisonOperator.In);
@@ -230,7 +230,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Image>> SelectRangeAsync(List<int> IDs)
         {
             var connector = ConnectorFactory.CreateConnector<Image>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, IDs, ComparisonOperator.In);
             filter.Add(x => x.IsImage, true);
             filter.Add(x => x.IsArchived, false);

--- a/src/Sushi.Mediakiwi.Data/Data/Installer.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Installer.cs
@@ -109,7 +109,7 @@ namespace Sushi.Mediakiwi.Data
         public static IInstaller SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return connector.FetchSingle(filter);
         }
@@ -122,7 +122,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IInstaller> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return await connector.FetchSingleAsync(filter);
         }
@@ -156,7 +156,7 @@ namespace Sushi.Mediakiwi.Data
         public static IInstaller[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter).ToArray();
         }
 
@@ -167,7 +167,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IInstaller[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();

--- a/src/Sushi.Mediakiwi.Data/Data/Menu.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Menu.cs
@@ -74,7 +74,7 @@ namespace Sushi.Mediakiwi.Data
         public static IMenu[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Menu>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter).ToArray();
         }
 
@@ -84,7 +84,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IMenu[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Menu>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();
         }

--- a/src/Sushi.Mediakiwi.Data/Data/MenuItem.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/MenuItem.cs
@@ -144,7 +144,7 @@ namespace Sushi.Mediakiwi.Data
         public static IMenuItem[] SelectAll(int menuID)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.MenuID, menuID);
             filter.AddOrder(x => x.Position);
             filter.AddOrder(x => x.Sort);
@@ -158,7 +158,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IMenuItem[]> SelectAllAsync(int menuID)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.MenuID, menuID);
             filter.AddOrder(x => x.Position);
             filter.AddOrder(x => x.Sort);
@@ -173,7 +173,7 @@ namespace Sushi.Mediakiwi.Data
         public static IMenuItem[] SelectAll_Dashboard(int dashboardID)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.DashboardID, dashboardID);
             filter.AddOrder(x => x.MenuID);
             filter.AddOrder(x => x.Position);
@@ -188,7 +188,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IMenuItem[]> SelectAll_DashboardAsync(int dashboardID)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.DashboardID, dashboardID);
             filter.AddOrder(x => x.MenuID);
             filter.AddOrder(x => x.Position);

--- a/src/Sushi.Mediakiwi.Data/Data/MenuItemView.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/MenuItemView.cs
@@ -109,7 +109,7 @@ namespace Sushi.Mediakiwi.Data
         public static IMenuItemView[] SelectAll(int siteID, int roleID, params int[] items)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItemView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("Site", SqlDbType.Int, siteID);
             filter.AddParameter("Role", SqlDbType.Int, roleID);
 
@@ -174,7 +174,7 @@ order by
         public static async Task<List<IMenuItemView>> SelectAllAsync(int siteID, int roleID, params int[] items)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItemView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("Site", SqlDbType.Int, siteID);
             filter.AddParameter("Role", SqlDbType.Int, roleID);
 
@@ -241,7 +241,7 @@ order by
         public static IMenuItemView[] SelectAll_Dashboard(int dashboardID)
         {
             var connector = ConnectorFactory.CreateConnector<MenuItemView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("Dashboard", SqlDbType.Int, dashboardID);
             
             var result = connector.FetchAll(@"

--- a/src/Sushi.Mediakiwi.Data/Data/NotificationOverview.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/NotificationOverview.cs
@@ -59,7 +59,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<NotificationOverview> SelectAll(int filterSelection)
         {
             var connector = ConnectorFactory.CreateConnector<NotificationOverview>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("type", filterSelection);
 
             var sql = @"
@@ -92,7 +92,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<NotificationOverview>> SelectAllAsync(int filterSelection)
         {
             var connector = ConnectorFactory.CreateConnector<NotificationOverview>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("type", filterSelection);
 
             var sql = @"

--- a/src/Sushi.Mediakiwi.Data/Data/Page.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Page.cs
@@ -474,7 +474,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
 
             return connector.FetchAll(filter).ToArray();
@@ -494,7 +494,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Page> SelectAll(int folderID, PageFolderSortType folderType = PageFolderSortType.Folder, PageReturnProperySet propertySet = PageReturnProperySet.All, PageSortBy sort = PageSortBy.SortOrder, bool onlyReturnPublishedPages = false)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
 
             if (sort == PageSortBy.Name)
@@ -558,7 +558,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Page>> SelectAllAsync(int folderID, PageFolderSortType folderType = PageFolderSortType.Folder, PageReturnProperySet propertySet = PageReturnProperySet.All, PageSortBy sort = PageSortBy.SortOrder, bool onlyReturnPublishedPages = false)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
 
             if (sort == PageSortBy.Name)
@@ -616,7 +616,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -630,7 +630,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllAsync(DateTime lastModified)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.Add(x => x.Updated, lastModified, ComparisonOperator.GreaterThanOrEquals);
 
@@ -646,7 +646,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllChildren(int masterID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.Add(x => x.MasterID, masterID);
 
@@ -661,7 +661,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllChildrenAsync(int masterID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.MasterID);
             filter.Add(x => x.MasterID, masterID);
 
@@ -773,7 +773,7 @@ namespace Sushi.Mediakiwi.Data
             {
                 connector.Save(this);
 
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisId", ID);
 
                 connector.ExecuteNonQuery(@"
@@ -811,7 +811,7 @@ namespace Sushi.Mediakiwi.Data
             {
                 await connector.SaveAsync(this);
 
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisId", ID);
 
                 await connector.ExecuteNonQueryAsync(@"
@@ -898,7 +898,7 @@ namespace Sushi.Mediakiwi.Data
         public bool Delete()
         {
             var connector = ConnectorFactory.CreateConnector(new PageMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
 
             connector.ExecuteNonQuery(@"DELETE FROM [wim_componentVersions] WHERE [ComponentVersion_Page_Key] IN (SELECT [Page_Key] FROM [wim_pages] WHERE ([Page_Key] = @thisId OR [Page_Master_Key] = @thisId))", filter);
@@ -915,7 +915,7 @@ namespace Sushi.Mediakiwi.Data
         public async Task<bool> DeleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector(new PageMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
 
             await connector.ExecuteNonQueryAsync(@"DELETE FROM [wim_componentVersions] WHERE [ComponentVersion_Page_Key] IN (SELECT [Page_Key] FROM [wim_pages] WHERE ([Page_Key] = @thisId OR [Page_Master_Key] = @thisId))", filter);
@@ -941,7 +941,7 @@ namespace Sushi.Mediakiwi.Data
             if (!m_IsPageFullyCachableSet)
             {
                 var connector = ConnectorFactory.CreateConnector<Page>();
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@templateId", TemplateID);
                 int count = connector.ExecuteScalar<int>("SELECT COUNT(*) FROM [wim_ComponentTemplates] JOIN [wim_AvailableTemplates] ON [AvailableTemplates_ComponentTemplate_Key] = [ComponentTemplate_Key] WHERE [ComponentTemplate_CacheLevel] = 0 AND [AvailableTemplates_PageTemplate_Key] = @templateId", filter);
 
@@ -1065,7 +1065,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOne(Guid guid, bool returnOnlyPublishedPage = false)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             if (returnOnlyPublishedPage)
@@ -1085,7 +1085,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneAsync(Guid guid, bool returnOnlyPublishedPage = false)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             if (returnOnlyPublishedPage)
@@ -1138,7 +1138,7 @@ namespace Sushi.Mediakiwi.Data
         public static bool UpdateSortOrder(int ID, int sortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@sortOrder", sortOrder);
             filter.AddParameter("@thisId", ID);
 
@@ -1156,7 +1156,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<bool> UpdateSortOrderAsync(int ID, int sortOrder)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@sortOrder", sortOrder);
             filter.AddParameter("@thisId", ID);
 
@@ -1174,7 +1174,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOneBySubFolder(int subFolderID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.SubFolderID, subFolderID);
 
@@ -1195,7 +1195,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneBySubFolderAsync(int subFolderID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.SubFolderID, subFolderID);
 
@@ -1216,7 +1216,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOne(int ID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ID, ID);
 
@@ -1250,7 +1250,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOne(string path, bool returnOnlyPublishedPage, int? siteId)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.InternalPath, path);
             if (siteId.GetValueOrDefault(0) > 0)
@@ -1286,7 +1286,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneAsync(string path, bool returnOnlyPublishedPage, int? siteId)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.InternalPath, path);
 
@@ -1312,7 +1312,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneAsync(int ID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ID, ID);
 
@@ -1333,7 +1333,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOneBasedOnName(string pageName, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.InternalPath, string.Concat("%/", pageName), ComparisonOperator.Like);
 
             if (returnOnlyPublishedPage)
@@ -1353,7 +1353,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneBasedOnNameAsync(string pageName, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.InternalPath, string.Concat("%/", pageName), ComparisonOperator.Like);
 
             if (returnOnlyPublishedPage)
@@ -1383,7 +1383,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOneDefault(int folderID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FolderID, folderID);
             filter.Add(x => x.IsFolderDefault, true);
 
@@ -1404,7 +1404,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page> SelectOneDefaultAsync(int folderID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FolderID, folderID);
             filter.Add(x => x.IsFolderDefault, true);
 
@@ -1427,7 +1427,7 @@ namespace Sushi.Mediakiwi.Data
         public static void UpdateDefault(int ID, int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", ID);
             filter.AddParameter("@folderId", folderID);
 
@@ -1446,7 +1446,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task UpdateDefaultAsync(int ID, int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", ID);
             filter.AddParameter("@folderId", folderID);
 
@@ -1511,7 +1511,7 @@ namespace Sushi.Mediakiwi.Data
         public bool IsPageAlreadyTaken(int folderID, string page)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageName", page);
             filter.AddParameter("@folderId", folderID);
             var count = connector.ExecuteScalar<int>("SELECT COUNT(*) FROM [wim_pages] WHERE [page_Folder_Key] = @folderId AND [Page_Name] = @pageName", filter);
@@ -1527,7 +1527,7 @@ namespace Sushi.Mediakiwi.Data
         public async Task<bool> IsPageAlreadyTakenAsync(int folderID, string page)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageName", page);
             filter.AddParameter("@folderId", folderID);
             var count = await connector.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM [wim_pages] WHERE [page_Folder_Key] = @folderId AND [Page_Name] = @pageName", filter);
@@ -1542,7 +1542,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task DeleteAllComponentSearchReferencesAsync(int ID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", ID);
 
             await connector.ExecuteNonQueryAsync(@"
@@ -1568,7 +1568,7 @@ namespace Sushi.Mediakiwi.Data
             await DeleteAllComponentSearchReferencesAsync(ID);
 
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", ID);
 
             await connector.ExecuteNonQueryAsync(@"DELETE FROM [wim_Components] WHERE [Component_Page_Key] = @pageId", filter);
@@ -1587,7 +1587,7 @@ namespace Sushi.Mediakiwi.Data
                 return new Page[0];
 
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             string query = string.Format("%{0}%", searchQuery.Replace(" ", "%"));
             filter.AddParameter("@query", query);
@@ -1615,7 +1615,7 @@ namespace Sushi.Mediakiwi.Data
                 return new Page[0];
 
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             string query = string.Format("%{0}%", searchQuery.Replace(" ", "%"));
             filter.AddParameter("@query", query);
@@ -1640,7 +1640,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAll(int[] keylist)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, keylist, ComparisonOperator.In);
 
             return connector.FetchAll(filter).ToArray();
@@ -1655,7 +1655,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllAsync(int[] keylist)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, keylist, ComparisonOperator.In);
 
             var result = await connector.FetchAllAsync(filter);
@@ -1670,7 +1670,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllBasedOnPageTemplate(int pageTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, pageTemplateID);
 
             return connector.FetchAll(filter).ToArray();
@@ -1684,7 +1684,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllBasedOnPageTemplateAsync(int pageTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, pageTemplateID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -1699,7 +1699,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllBasedOnPageTemplate(int[] pageTemplateArray)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, pageTemplateArray, ComparisonOperator.In);
 
             return connector.FetchAll(filter).ToArray();
@@ -1714,7 +1714,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllBasedOnPageTemplateAsync(int[] pageTemplateArray)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, pageTemplateArray, ComparisonOperator.In);
 
             var result = await connector.FetchAllAsync(filter);
@@ -1729,7 +1729,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllBySite(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
 
             return connector.FetchAll(filter).ToArray();
@@ -1757,7 +1757,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page SelectOneChild(int pageID, int siteID, bool returnOnlyPublishedPage)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddSql("Page_Master_Key = @Page OR Page_Key = @Page");
             filter.AddParameter("Page", pageID);
             filter.Add(x => x.SiteID, siteID);
@@ -1779,7 +1779,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllBySiteAsync(int siteID)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -1870,7 +1870,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllByCustomDate(int folderID, int? pageTemplateID, bool desc, int maxReturnCount)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (maxReturnCount != 0)
             {
@@ -1914,7 +1914,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllByCustomDateAsync(int folderID, int? pageTemplateID, bool desc, int maxReturnCount)
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (maxReturnCount != 0)
             {
@@ -1954,7 +1954,7 @@ namespace Sushi.Mediakiwi.Data
         public static Page[] SelectAllDated()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@currentDate", DateTime.Now);
             filter.AddSql("((NOT [Page_Publish] IS NULL OR NOT [Page_Expire] IS NULL) and ([Page_Publish] <= @currentDate OR [Page_Expire] <= @currentDate))");
 
@@ -1968,7 +1968,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Page[]> SelectAllDatedAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@currentDate", DateTime.Now);
             filter.AddSql("((NOT [Page_Publish] IS NULL OR NOT [Page_Expire] IS NULL) and ([Page_Publish] <= @currentDate OR [Page_Expire] <= @currentDate))");
 

--- a/src/Sushi.Mediakiwi.Data/Data/PageMapping.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PageMapping.cs
@@ -199,7 +199,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPageMapping SelectOneByPageAndQuery(int pageID, string query)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Query, query);
             filter.Add(x => x.PageID, pageID);
 
@@ -215,7 +215,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPageMapping> SelectOneByPageAndQueryAsync(int pageID, string query)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Query, query);
             filter.Add(x => x.PageID, pageID);
 
@@ -235,7 +235,7 @@ namespace Sushi.Mediakiwi.Data
             prefix += "%";
 
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Path, prefix, ComparisonOperator.Like);
 
             var result = connector.FetchAll(filter);
@@ -255,7 +255,7 @@ namespace Sushi.Mediakiwi.Data
             prefix += "%";
 
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Path, prefix, ComparisonOperator.Like);
 
             var result = await connector.FetchAllAsync(filter);
@@ -270,7 +270,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<IPageMapping> SelectAllBasedOnPageID(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             var result = connector.FetchAll(filter);
@@ -285,7 +285,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<IPageMapping>> SelectAllBasedOnPageIDAsync(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -299,7 +299,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<IPageMapping> SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var result = connector.FetchAll(filter);
             return result.ToList<IPageMapping>();
@@ -312,7 +312,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<IPageMapping>> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var result = await connector.FetchAllAsync(filter);
             return result.ToList<IPageMapping>();
@@ -327,7 +327,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<IPageMapping> SelectAll(int typeId, bool onlyActive)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (typeId > 0)
             {
@@ -358,7 +358,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<IPageMapping>> SelectAllAsync(int typeId, bool onlyActive)
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             if (typeId > 0)
             {

--- a/src/Sushi.Mediakiwi.Data/Data/PageTemplate.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PageTemplate.cs
@@ -411,7 +411,7 @@ namespace Sushi.Mediakiwi.Data
         public bool Delete()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
             try
             {
@@ -433,7 +433,7 @@ namespace Sushi.Mediakiwi.Data
         public async Task<bool> DeleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@thisId", ID);
             try
             {
@@ -456,7 +456,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return connector.FetchSingle(filter);
         }
@@ -469,7 +469,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return await connector.FetchSingleAsync(filter);
         }
@@ -483,7 +483,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate SelectOneOverwrite(int siteID, int pageTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.OverwriteSiteKey, siteID);
             filter.Add(x => x.OverwriteTemplateKey, pageTemplateID);
 
@@ -499,7 +499,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate> SelectOneOverwriteAsync(int siteID, int pageTemplateID)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.OverwriteSiteKey, siteID);
             filter.Add(x => x.OverwriteTemplateKey, pageTemplateID);
 
@@ -514,7 +514,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate SelectOne(string location)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Location, location);
 
             return connector.FetchSingle(filter);
@@ -528,7 +528,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate> SelectOneAsync(string location)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Location, location);
 
             return await connector.FetchSingleAsync(filter);
@@ -542,7 +542,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate SelectOneByReference(int referenceID)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceID);
 
             return connector.FetchSingle(filter);
@@ -556,7 +556,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate> SelectOneByReferenceAsync(int referenceID)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ReferenceID, referenceID);
 
             return await connector.FetchSingleAsync(filter);
@@ -569,7 +569,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ReferenceID);
 
             return connector.FetchAll(filter).ToArray();
@@ -582,7 +582,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ReferenceID);
 
             var result = await connector.FetchAllAsync(filter);
@@ -596,7 +596,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate[] SelectAllSortedByName()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
 
             return connector.FetchAll(filter).ToArray();
@@ -609,7 +609,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate[]> SelectAllSortedByNameAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
 
             var result = await connector.FetchAllAsync(filter);
@@ -625,7 +625,7 @@ namespace Sushi.Mediakiwi.Data
         public static PageTemplate[] SearchAll(int siteID, string name)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ReferenceID);
 
             if (siteID > 0)
@@ -649,7 +649,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PageTemplate[]> SearchAllAsync(int siteID, string name)
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ReferenceID);
 
             if (siteID > 0)

--- a/src/Sushi.Mediakiwi.Data/Data/PageVersion.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PageVersion.cs
@@ -135,7 +135,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<IPageVersion> SelectAllOfPage(int pageID)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             return connector.FetchAll(filter).ToList<IPageVersion>();
@@ -149,7 +149,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<IPageVersion>> SelectAllOfPageAsync(int pageID)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PageID, pageID);
 
             var result = await connector.FetchAllAsync(filter);

--- a/src/Sushi.Mediakiwi.Data/Data/Portal.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Portal.cs
@@ -167,7 +167,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPortal SelectOne(string authenticode)
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Authenticode, authenticode);
 
             return connector.FetchSingle(filter);
@@ -181,7 +181,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPortal> SelectOneAsync(string authenticode)
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.Authenticode, authenticode);
 
             return await connector.FetchSingleAsync(filter);
@@ -195,7 +195,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPortal SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return connector.FetchSingle(filter);
@@ -209,7 +209,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPortal> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
 
             return await connector.FetchSingleAsync(filter);
@@ -223,7 +223,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPortal[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             return connector.FetchAll(filter).ToArray();
         }
@@ -236,7 +236,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPortal[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var result = await connector.FetchAllAsync(filter);
             return result.ToArray();

--- a/src/Sushi.Mediakiwi.Data/Data/PortalRight.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PortalRight.cs
@@ -52,7 +52,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPortalRight SelectOne(int ID)
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, ID);
             return connector.FetchSingle(filter);
         }
@@ -65,7 +65,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPortalRight> SelectOneAsync(int ID)
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, ID);
             return await connector.FetchSingleAsync(filter);
         }
@@ -78,7 +78,7 @@ namespace Sushi.Mediakiwi.Data
         public static IPortalRight[] SelectAll(int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             return connector.FetchAll(filter).ToArray();
         }
@@ -91,7 +91,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IPortalRight[]> SelectAllAsync(int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             var result = await connector.FetchAllAsync(filter);
 

--- a/src/Sushi.Mediakiwi.Data/Data/Property.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Property.cs
@@ -365,7 +365,7 @@ namespace Sushi.Mediakiwi.Data
         public static Property SelectOne(int listID, string fieldName, int? listTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ListID, listID);
             if (listTypeID.HasValue)
                 filter.Add(x => x.ContentTypeID, listTypeID.Value);
@@ -377,7 +377,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Property> SelectAllByTemplate(int templateid)
         {
             var connector = new Connector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, templateid);
             filter.AddOrder(x => x.SortOrder);
             return connector.FetchAll(filter);
@@ -386,7 +386,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Property>> SelectAllByTemplateAsync(int templateid)
         {
             var connector = new Connector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.TemplateID, templateid);
             filter.AddOrder(x => x.SortOrder);
             return await connector.FetchAllAsync(filter);
@@ -402,7 +402,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Property> SelectOneAsync(int listID, string fieldName, int? listTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ListID, listID);
             if (listTypeID.HasValue)
                 filter.Add(x => x.ContentTypeID, listTypeID.Value);
@@ -418,7 +418,7 @@ namespace Sushi.Mediakiwi.Data
         public static bool HasContentContainer(int listID)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ListID, listID);
             filter.Add(x => x.ContentTypeID, ContentType.ContentContainer);
 
@@ -433,7 +433,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<bool> HasContentContainerAsync(int listID)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ListID, listID);
             filter.Add(x => x.ContentTypeID, ContentType.ContentContainer);
 
@@ -448,7 +448,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Property> SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter);
         }
 
@@ -459,7 +459,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Property>> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return await connector.FetchAllAsync(filter);
         }
 
@@ -475,7 +475,7 @@ namespace Sushi.Mediakiwi.Data
         public static List<Property> SelectAllByFieldName(string fieldName)
         {
             var connector = new Connector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FieldName, fieldName);
             return connector.FetchAll(filter);
         }
@@ -487,7 +487,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<List<Property>> SelectAllByFieldNameAsync(string fieldName)
         {
             var connector = new Connector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FieldName, fieldName);
             return await connector.FetchAllAsync(filter);
         }
@@ -500,7 +500,7 @@ namespace Sushi.Mediakiwi.Data
         public static Property[] SelectAll(int[] IDs)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, IDs, ComparisonOperator.In);
 
             return connector.FetchAll(filter).ToArray();
@@ -518,7 +518,7 @@ namespace Sushi.Mediakiwi.Data
         public static Property[] SelectAll(int listID, int? listTypeID, bool showEmptyTypes, bool onlyReturnFlexibleProperties = false)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
         
             filter.Add(x => x.ListID, listID);
 
@@ -549,7 +549,7 @@ namespace Sushi.Mediakiwi.Data
         public static Property[] SelectAll(int listID)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ListID, listID);
 
             return connector.FetchAll(filter).ToArray();
@@ -563,7 +563,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<Property[]> SelectAllAsync(int[] IDs)
         {
             var connector = ConnectorFactory.CreateConnector<Property>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, IDs, ComparisonOperator.In);
 
             var result = await connector.FetchAllAsync(filter);
@@ -585,7 +585,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 connector.ExecuteNonQuery("UPDATE [wim_Properties] SET [Property_SortOrder] = [Property_Key] WHERE [Property_Key] = @thisID", filter);
@@ -610,7 +610,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 await connector.ExecuteNonQueryAsync("UPDATE [wim_Properties] SET [Property_SortOrder] = [Property_Key] WHERE [Property_Key] = @thisID", filter);

--- a/src/Sushi.Mediakiwi.Data/Data/PropertyOption.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PropertyOption.cs
@@ -69,7 +69,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 connector.ExecuteNonQuery("UPDATE [wim_PropertyOptions] SET [PropertyOption_SortOrder] = [PropertyOption_Key] WHERE [PropertyOption_Key] = @thisID", filter);
@@ -94,7 +94,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 await connector.ExecuteNonQueryAsync("UPDATE [wim_PropertyOptions] SET [PropertyOption_SortOrder] = [PropertyOption_Key] WHERE [PropertyOption_Key] = @thisID", filter);
@@ -139,7 +139,7 @@ namespace Sushi.Mediakiwi.Data
                 return true;
 
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@formElementID", formElementID);
 
             connector.ExecuteNonQuery("DELETE FROM [wim_PropertyOptions] WHERE [PropertyOption_Property_Key] = @formElementID", filter);
@@ -159,7 +159,7 @@ namespace Sushi.Mediakiwi.Data
                 return true;
 
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@formElementID", formElementID);
 
             await connector.ExecuteNonQueryAsync("DELETE FROM [wim_PropertyOptions] WHERE [PropertyOption_Property_Key] = @formElementID", filter);
@@ -200,7 +200,7 @@ namespace Sushi.Mediakiwi.Data
         public static PropertyOption[] SelectAll(int propertyID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PropertyID, propertyID);
             filter.AddOrder(x => x.SortOrderID);
 
@@ -215,7 +215,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PropertyOption[]> SelectAllAsync(int propertyID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.PropertyID, propertyID);
             filter.AddOrder(x => x.SortOrderID);
 
@@ -230,7 +230,7 @@ namespace Sushi.Mediakiwi.Data
         public static PropertyOption[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrderID);
 
             return connector.FetchAll(filter).ToArray();
@@ -243,7 +243,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PropertyOption[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PropertyOption>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrderID);
 
             var result = await connector.FetchAllAsync(filter);

--- a/src/Sushi.Mediakiwi.Data/Data/PropertySearchColumn.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/PropertySearchColumn.cs
@@ -130,7 +130,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 connector.ExecuteNonQuery("UPDATE [Wim_PropertySearchColumns] SET [PropertySearchColumn_SortOrder] = [PropertySearchColumn_Key] WHERE [PropertySearchColumn_Key] = @thisID", filter);
@@ -155,7 +155,7 @@ namespace Sushi.Mediakiwi.Data
 
             if (shouldSetSortorder)
             {
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
                 filter.AddParameter("@thisID", ID);
 
                 await connector.ExecuteNonQueryAsync("UPDATE [Wim_PropertySearchColumns] SET [PropertySearchColumn_SortOrder] = [PropertySearchColumn_Key] WHERE [PropertySearchColumn_Key] = @thisID", filter);
@@ -195,7 +195,7 @@ namespace Sushi.Mediakiwi.Data
         public static PropertySearchColumn SelectOneHighlight(int componentlistID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertySearchColumn>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ListID, componentlistID);
             filter.Add(x => x.IsHighlight, true);
@@ -210,7 +210,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PropertySearchColumn> SelectOneHighlightAsync(int componentlistID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertySearchColumn>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ListID, componentlistID);
             filter.Add(x => x.IsHighlight, true);
@@ -225,7 +225,7 @@ namespace Sushi.Mediakiwi.Data
         public static PropertySearchColumn[] SelectAll(int componentlistID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertySearchColumn>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ListID, componentlistID);
             return connector.FetchAll(filter).ToArray();
@@ -239,7 +239,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<PropertySearchColumn[]> SelectAllAsync(int componentlistID)
         {
             var connector = ConnectorFactory.CreateConnector<PropertySearchColumn>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.ListID, componentlistID);
             var result = await connector.FetchAllAsync(filter);

--- a/src/Sushi.Mediakiwi.Data/Data/RoleRight.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/RoleRight.cs
@@ -72,7 +72,7 @@ namespace Sushi.Mediakiwi.Data
                 int sortOrder = 0;
                 foreach (SubList.SubListitem item in subList.Items)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", item.ID);
                     filter.AddParameter("@folderID", folderID);
@@ -110,7 +110,7 @@ namespace Sushi.Mediakiwi.Data
                 int sortOrder = 0;
                 foreach (SubList.SubListitem item in subList.Items)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", item.ID);
                     filter.AddParameter("@folderID", folderID);
@@ -148,7 +148,7 @@ namespace Sushi.Mediakiwi.Data
 
                 foreach (SubList.SubListitem item in subList.Items)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", roleID);
                     filter.AddParameter("@folderID", item.ID);
@@ -186,7 +186,7 @@ namespace Sushi.Mediakiwi.Data
 
                 foreach (SubList.SubListitem item in subList.Items)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", roleID);
                     filter.AddParameter("@folderID", item.ID);
@@ -222,7 +222,7 @@ namespace Sushi.Mediakiwi.Data
                 int sortOrder = 0;
                 foreach (int item in subList)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", roleID);
                     filter.AddParameter("@folderID", item);
@@ -258,7 +258,7 @@ namespace Sushi.Mediakiwi.Data
                 int sortOrder = 0;
                 foreach (int item in subList)
                 {
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", roleID);
                     filter.AddParameter("@folderID", item);
@@ -297,7 +297,7 @@ namespace Sushi.Mediakiwi.Data
                 {
                     if (item.Value == Access.Inherit) continue;
 
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", userOrRoleID);
                     filter.AddParameter("@folderID", item.Key);
@@ -337,7 +337,7 @@ namespace Sushi.Mediakiwi.Data
                 {
                     if (item.Value == Access.Inherit) continue;
 
-                    var filter = connector.CreateDataFilter();
+                    var filter = connector.CreateQuery();
 
                     filter.AddParameter("@itemID", userOrRoleID);
                     filter.AddParameter("@folderID", item.Key);
@@ -365,7 +365,7 @@ namespace Sushi.Mediakiwi.Data
         public static RoleRight[] SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ItemID);
             filter.AddOrder(x => x.SortOrder);
             return connector.FetchAll(filter).ToArray();
@@ -378,7 +378,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<RoleRight[]> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ItemID);
             filter.AddOrder(x => x.SortOrder);
 
@@ -394,7 +394,7 @@ namespace Sushi.Mediakiwi.Data
         public static RoleRight[] SelectAll(int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.AddOrder(x => x.ItemID);
             filter.AddOrder(x => x.SortOrder);
@@ -410,7 +410,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<RoleRight[]> SelectAllAsync(int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.AddOrder(x => x.ItemID);
             filter.AddOrder(x => x.SortOrder);
@@ -428,7 +428,7 @@ namespace Sushi.Mediakiwi.Data
         public static RoleRight[] SelectAll(int roleID, RoleRightType type)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.Add(x => x.TypeID, (int)type);
             filter.AddOrder(x => x.ItemID);
@@ -446,7 +446,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<RoleRight[]> SelectAllAsync(int roleID, RoleRightType type)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.Add(x => x.TypeID, (int)type);
             filter.AddOrder(x => x.ItemID);
@@ -464,7 +464,7 @@ namespace Sushi.Mediakiwi.Data
         private static void Prepare(RoleRightType type, int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@roleID", roleID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -480,7 +480,7 @@ namespace Sushi.Mediakiwi.Data
         private static async Task PrepareAsync(RoleRightType type, int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@roleID", roleID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -497,7 +497,7 @@ namespace Sushi.Mediakiwi.Data
             RoleRightType type = RoleRightType.Folder;
 
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@childID", folderID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -514,7 +514,7 @@ namespace Sushi.Mediakiwi.Data
             RoleRightType type = RoleRightType.Folder;
 
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@childID", folderID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -531,7 +531,7 @@ namespace Sushi.Mediakiwi.Data
             RoleRightType type = RoleRightType.Folder;
 
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@childID", folderID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -548,7 +548,7 @@ namespace Sushi.Mediakiwi.Data
             RoleRightType type = RoleRightType.Folder;
 
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@childID", folderID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -564,7 +564,7 @@ namespace Sushi.Mediakiwi.Data
         private static void CleanUp(RoleRightType type, int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@roleID", roleID);
             filter.AddParameter("@childTypeID", (int)type);
 
@@ -580,7 +580,7 @@ namespace Sushi.Mediakiwi.Data
         private static async Task CleanUpAsync(RoleRightType type, int roleID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@roleID", roleID);
             filter.AddParameter("@childTypeID", (int)type);
 

--- a/src/Sushi.Mediakiwi.Data/Data/RoleRightAccessItem.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/RoleRightAccessItem.cs
@@ -42,7 +42,7 @@ namespace Sushi.Mediakiwi.Data
         public static IRoleRightAccessItem[] Select(int roleID, int typeID, int childTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRightAccessItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.Add(x => x.TypeID, typeID);
             filter.Add(x => x.ChildTypeID, childTypeID);
@@ -59,7 +59,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IRoleRightAccessItem[]> SelectAsync(int roleID, int typeID, int childTypeID)
         {
             var connector = ConnectorFactory.CreateConnector<RoleRightAccessItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.RoleID, roleID);
             filter.Add(x => x.TypeID, typeID);
             filter.Add(x => x.ChildTypeID, childTypeID);

--- a/src/Sushi.Mediakiwi.Data/Data/SearchView.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/SearchView.cs
@@ -81,7 +81,7 @@ namespace Sushi.Mediakiwi.Data
         public static ISearchView[] SelectAll(int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FolderID, folderID);
             filter.AddOrder(x => x.SortOrder);
 
@@ -96,7 +96,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ISearchView[]> SelectAllAsync(int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FolderID, folderID);
             filter.AddOrder(x => x.SortOrder);
 
@@ -114,7 +114,7 @@ namespace Sushi.Mediakiwi.Data
         public static ISearchView[] SelectAll(int? siteID, int? filterType, string search)
         {
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             if (string.IsNullOrEmpty(search) == false)
@@ -143,7 +143,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ISearchView[]> SelectAllAsync(int? siteID, int? filterType, string search)
         {
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
 
             if (string.IsNullOrEmpty(search) == false)
@@ -174,7 +174,7 @@ namespace Sushi.Mediakiwi.Data
                 return null;
 
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ID, items, ComparisonOperator.In);
 
@@ -192,7 +192,7 @@ namespace Sushi.Mediakiwi.Data
                 return null;
 
             var connector = ConnectorFactory.CreateConnector<SearchView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.SortOrder);
             filter.Add(x => x.ID, items, ComparisonOperator.In);
 

--- a/src/Sushi.Mediakiwi.Data/Data/SharedField.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/SharedField.cs
@@ -108,7 +108,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<SharedField> FetchAll()
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.FieldName);
             var result = connector.FetchAll(filter);
             return result;
@@ -122,7 +122,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICollection<SharedField>> FetchAllAsync(string search)
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             if (string.IsNullOrWhiteSpace(search) == false)
             {
                 filter.Add(x => x.FieldName, $"%{search}%", ComparisonOperator.Like);
@@ -150,7 +150,7 @@ namespace Sushi.Mediakiwi.Data
         public static SharedField FetchSingle(string fieldName, ContentType contentType)
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.FieldName, fieldName);
             filter.Add(x => x.ContentTypeID, contentType);
@@ -162,7 +162,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<SharedField> FetchSingleAsync(string fieldName, ContentType contentType)
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.Add(x => x.FieldName, fieldName);
             filter.Add(x => x.ContentTypeID, contentType);
@@ -174,7 +174,7 @@ namespace Sushi.Mediakiwi.Data
         public static SharedField FetchSingleForComponentTemplate(string fieldName, ContentType contentType, int componentTemplateId)
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var props = Property.SelectAllByTemplate(componentTemplateId);
             var matchingProp = props.FirstOrDefault(x => x.FieldName == fieldName && x.IsSharedField);
@@ -192,7 +192,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<SharedField> FetchSingleForComponentTemplateAsync(string fieldName, ContentType contentType, int componentTemplateId)
         {
             var connector = new Connector<SharedField>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             var props = await Property.SelectAllByTemplateAsync(componentTemplateId);
             var matchingProp = props.FirstOrDefault(x => x.FieldName == fieldName && x.IsSharedField);

--- a/src/Sushi.Mediakiwi.Data/Data/SharedFieldTranslation.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/SharedFieldTranslation.cs
@@ -282,7 +282,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<SharedFieldTranslation> FetchAll()
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = connector.FetchAll(filter);
             return result;
         }
@@ -294,7 +294,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICollection<SharedFieldTranslation>> FetchAllAsync()
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             return result;
         }
@@ -307,7 +307,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<SharedFieldTranslation> FetchAllForField(int sharedFieldID)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FieldID, sharedFieldID);
             var result = connector.FetchAll(filter);
             return result;
@@ -321,7 +321,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICollection<SharedFieldTranslation>> FetchAllForFieldAsync(int sharedFieldID)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.FieldID, sharedFieldID);
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             return result;
@@ -335,7 +335,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<SharedFieldTranslation> FetchAllForSite(int siteId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteId);
             var result = connector.FetchAll(filter);
             return result;
@@ -349,7 +349,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<ICollection<SharedFieldTranslation>> FetchAllForSiteAsync(int siteId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteId);
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             return result;
@@ -363,7 +363,7 @@ namespace Sushi.Mediakiwi.Data
         public static ICollection<SharedFieldTranslation> FetchAllForPage(int pageId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageId);
 
             var result = connector.FetchAll(@"SELECT fields.* FROM [dbo].[wim_SharedFieldView] AS fields
@@ -382,7 +382,7 @@ WHERE props.[Property_IsShared] = 1 AND comps.[Component_Page_Key] = @pageId", f
         public static async Task<ICollection<SharedFieldTranslation>> FetchAllForPageAsync(int pageId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageId", pageId);
 
             var result = await connector.FetchAllAsync(@"SELECT fields.* FROM [dbo].[wim_SharedFieldView] AS fields
@@ -414,7 +414,7 @@ WHERE props.[Property_IsShared] = 1 AND comps.[Component_Page_Key] = @pageId", f
         public static SharedFieldTranslation FetchSingleForFieldAndSite(int sharedFieldId, int siteId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteId);
             filter.Add(x => x.FieldID, sharedFieldId);
             var result = connector.FetchSingle(filter);
@@ -430,7 +430,7 @@ WHERE props.[Property_IsShared] = 1 AND comps.[Component_Page_Key] = @pageId", f
         public static async Task<SharedFieldTranslation> FetchSingleForFieldAndSiteAsync(int sharedFieldId, int siteId)
         {
             var connector = new Connector<SharedFieldTranslation>(new SharedFieldTranslationMap(false));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.SiteID, siteId);
             filter.Add(x => x.FieldID, sharedFieldId);
             var result = await connector.FetchSingleAsync(filter).ConfigureAwait(false);

--- a/src/Sushi.Mediakiwi.Data/Data/Site.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Site.cs
@@ -354,7 +354,7 @@ namespace Sushi.Mediakiwi.Data
         public void Delete()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@siteID", ID);
 
             if (this.HasPages || this.HasLists)
@@ -395,7 +395,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public async Task DeleteAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@siteID", ID);
 
             if (this.HasPages || this.HasLists)
@@ -454,7 +454,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static Site SelectOne(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return connector.FetchSingle(filter);
         }
@@ -466,7 +466,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<Site> SelectOneAsync(Guid guid)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, guid);
             return await connector.FetchSingleAsync(filter);
         }
@@ -552,7 +552,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static Site SelectOneByPage(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageID", pageID);
 
             return connector.FetchSingle(@"SELECT TOP 1 *
@@ -571,7 +571,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<Site> SelectOneByPageAsync(int pageID)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@pageID", pageID);
 
             return await connector.FetchSingleAsync(@"SELECT TOP 1 *
@@ -589,7 +589,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static Site SelectOneByFolder(int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderID", folderID);
 
             return connector.FetchSingle(@"SELECT TOP 1 *
@@ -606,7 +606,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<Site> SelectOneByFolderAsync(int folderID)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@folderID", folderID);
 
             return await connector.FetchSingleAsync(@"SELECT TOP 1 *
@@ -625,7 +625,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static Site SelectOneSiteResolution(string searchPath, bool excludeAdmin = false)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.DefaultFolder, SortOrder.DESC);
             filter.AddParameter("@searchPath", $"'{searchPath}%'");
 
@@ -649,7 +649,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<Site> SelectOneSiteResolutionAsync(string searchPath, bool excludeAdmin = false)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.DefaultFolder, SortOrder.DESC);
             filter.AddParameter("@searchPath", $"'{searchPath}%'");
 
@@ -671,7 +671,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static Site SelectOne(string searchPath)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.DefaultFolder, SortOrder.DESC);
 
             if (string.IsNullOrEmpty(searchPath))
@@ -689,7 +689,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<Site> SelectOneAsync(string searchPath)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.DefaultFolder, SortOrder.DESC);
 
             if (string.IsNullOrEmpty(searchPath))
@@ -920,7 +920,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         internal static List<Site> SelectAllActive()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Type);
             filter.AddOrder(x => x.Name);
 
@@ -936,7 +936,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         internal static async Task<List<Site>> SelectAllActiveAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Type);
             filter.AddOrder(x => x.Name);
 
@@ -952,7 +952,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static List<Site> SelectAll(bool ignoreAdministration = true)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Type);
             filter.AddOrder(x => x.Name);
 
@@ -968,7 +968,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<List<Site>> SelectAllAsync(bool ignoreAdministration = true)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Type);
             filter.AddOrder(x => x.Name);
 
@@ -994,7 +994,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static List<Site> SelectAll(string title, FolderType type)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.AddParameter("@folderTypeID", (int)type);
             filter.AddParameter("@siteDisplayName", title);
@@ -1026,7 +1026,7 @@ delete from wim_ComponentVersions where ComponentVersion_Page_Key in
         public static async Task<List<Site>> SelectAllAsync(string title, FolderType type)
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.Name);
             filter.AddParameter("@folderTypeID", (int)type);
             filter.AddParameter("@siteDisplayName", title);

--- a/src/Sushi.Mediakiwi.Data/Data/Sys/SysColumn.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Sys/SysColumn.cs
@@ -39,7 +39,7 @@ namespace Sushi.Mediakiwi.Data.Sys
         public static async Task<List<SysColumn>> SelectAllAsync(string tableName)
         {
             var connector = new Connector<SysColumn>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             
             filter.AddParameter("@table", tableName);
             var sqlText = "select Name, prec, isnullable from syscolumns where id = (select object_id from sys.objects where name = @table) order by colorder";

--- a/src/Sushi.Mediakiwi.Data/Data/Sys/SysProcedure.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Sys/SysProcedure.cs
@@ -31,7 +31,7 @@ namespace Sushi.Mediakiwi.Data.Sys
         public static async Task<SysProcedure> FetchSingle(string tableName)
         {
             var connector = new Connector<SysProcedure>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@name", System.Data.SqlDbType.VarChar, tableName);
             var sqlText = "select ROUTINE_DEFINITION from INFORMATION_SCHEMA.ROUTINES WHERE SPECIFIC_NAME = @name";

--- a/src/Sushi.Mediakiwi.Data/Data/Sys/SysView.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Sys/SysView.cs
@@ -31,7 +31,7 @@ namespace Sushi.Mediakiwi.Data.Sys
         public static async Task<SysView> FetchSingle(string tableName)
         {
             var connector = new Connector<SysView>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             filter.AddParameter("@name", System.Data.SqlDbType.VarChar, tableName);
             var sqlText = "select VIEW_DEFINITION from INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME = @name";

--- a/src/Sushi.Mediakiwi.Data/Data/Visitor.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Visitor.cs
@@ -240,7 +240,7 @@ namespace Sushi.Mediakiwi.Data
         public static IVisitor Select(Guid visitorReference)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, visitorReference);
 
             return connector.FetchSingle(filter);
@@ -255,7 +255,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IVisitor> SelectAsync(Guid visitorReference)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.GUID, visitorReference);
 
             return await connector.FetchSingleAsync(filter);
@@ -318,7 +318,7 @@ namespace Sushi.Mediakiwi.Data
         public static IVisitor[] SelectAllByProfile(int profileId, int excludeVisitorID)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ProfileID, profileId);
 
             int minutes = Utility.ConvertToInt(CommonConfiguration.EXPIRATION_COOKIE_PROFILE, 0);
@@ -343,7 +343,7 @@ namespace Sushi.Mediakiwi.Data
         public static async Task<IVisitor[]> SelectAllByProfileAsync(int profileId, int excludeVisitorID)
         {
             var connector = Connector;
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ProfileID, profileId);
 
             int minutes = Utility.ConvertToInt(CommonConfiguration.EXPIRATION_COOKIE_VISITOR, 0);

--- a/src/Sushi.Mediakiwi.Data/Repositories/Sql/NotificationRepository.cs
+++ b/src/Sushi.Mediakiwi.Data/Repositories/Sql/NotificationRepository.cs
@@ -46,7 +46,7 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         /// <param name="group">The group.</param>
         public void DeleteAll(string group)
         {   
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@type", group);
 
             connector.ExecuteNonQuery("DELETE FROM [wim_Notifications] WHERE [Notification_Type] = @TYPE", filter);         
@@ -58,7 +58,7 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         /// <param name="group">The group.</param>
         public async Task DeleteAllAsync(string group)
         {   
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddParameter("@type", group);
 
             await connector.ExecuteNonQueryAsync("DELETE FROM [wim_Notifications] WHERE [Notification_Type] = @TYPE", filter).ConfigureAwait(false);
@@ -138,7 +138,7 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         /// <returns></returns>
         public sql.Notification[] SelectAll(string group, int selection, int? maxResult)
         {   
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             if (maxResult.GetValueOrDefault(0) > 0)
                 filter.MaxResults = maxResult.Value;
@@ -161,7 +161,7 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         /// <returns></returns>
         public async Task<sql.Notification[]> SelectAllAsync(string group, int selection, int? maxResult)
         {   
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.AddOrder(x => x.ID);
             filter.Add(x => x.Group, group);
             filter.Add(x => x.Selection, selection);

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>
+    <Version>8.1.5</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Demonstration/Example.cs
+++ b/src/Sushi.Mediakiwi.Demonstration/Example.cs
@@ -38,14 +38,14 @@ namespace Sushi.Mediakiwi.Demonstration
         public static async Task<List<ItemData>> SelectAllAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ItemData>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return await connector.FetchAllAsync(filter).ConfigureAwait(false);
         }
 
         public static List<ItemData> SelectAll()
         {
             var connector = ConnectorFactory.CreateConnector<ItemData>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             return connector.FetchAll(filter);
         }
 

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>
+    <Version>8.1.5</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Files/web.config
+++ b/src/Sushi.Mediakiwi.Files/web.config
@@ -8,7 +8,7 @@
       <handlers>
         <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>
-      <aspNetCore processPath="bin\Debug\netcoreapp3.1\Sushi.Mediakiwi.Files.exe" arguments="" stdoutLogEnabled="false" hostingModel="InProcess">
+      <aspNetCore processPath="bin\Debug\net6.0\Sushi.Mediakiwi.Files.exe" arguments="" stdoutLogEnabled="false" hostingModel="InProcess">
         <environmentVariables>
           <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="443" />
           <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>
+    <Version>8.1.5</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi/Cms/Console.cs
+++ b/src/Sushi.Mediakiwi/Cms/Console.cs
@@ -690,7 +690,6 @@ namespace Sushi.Mediakiwi.Beta.GeneratedCms
                     )
                 {
                     m_CurrentApplicationUser = ApplicationUser.SelectOne(CurrentVisitor.ApplicationUserID.Value, true);
-                    return m_CurrentApplicationUser;
                 }
 
                 if (m_CurrentApplicationUser == null && m_CurrentListInstance != null)

--- a/src/Sushi.Mediakiwi/Extention/ComponentListTemplateExtension.cs
+++ b/src/Sushi.Mediakiwi/Extention/ComponentListTemplateExtension.cs
@@ -31,7 +31,7 @@ namespace Sushi.Mediakiwi.Extention
                 // Override the Mapped table (wim_pages to the correct table)
                 connector.Map.Table(template.wim.m_sortOrderSqlTable);
 
-                var filter = connector.CreateDataFilter();
+                var filter = connector.CreateQuery();
 
                 // Query replacements
                 string sqlColumn = $"[{template.wim.m_sortOrderSqlColumn}]";

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.3</Version>    
+    <Version>8.1.5</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/test/Sushi.Mediakiwi.Test/ORM/ApplicationRoleTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ApplicationRoleTests.cs
@@ -413,7 +413,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -431,7 +431,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationRole>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ApplicationUserTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ApplicationUserTests.cs
@@ -741,7 +741,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -759,7 +759,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ApplicationUser>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ArticleTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ArticleTests.cs
@@ -403,7 +403,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -421,7 +421,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Article>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/AssetTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/AssetTests.cs
@@ -401,7 +401,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -419,7 +419,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Asset>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/AssetTypeTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/AssetTypeTests.cs
@@ -257,7 +257,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -275,7 +275,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<AssetType>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/AvailableTemplateTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/AvailableTemplateTests.cs
@@ -320,7 +320,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -338,7 +338,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<AvailableTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/CachingTest.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/CachingTest.cs
@@ -120,7 +120,7 @@ namespace Sushi.Mediakiwi.Test.ORM
             //run a delete command on the entity 'Page'
             //this will not delete anything in DB, but still will trigger a flush
             var connector = ConnectorFactory.CreateConnector(new Page.PageMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, -1);
             connector.Delete(filter);
 
@@ -143,7 +143,7 @@ namespace Sushi.Mediakiwi.Test.ORM
             //run a delete command on the entity 'Page'
             //this will not delete anything in DB, but still will trigger a flush
             var connector = ConnectorFactory.CreateConnector(new Page.PageMap(true));
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             filter.Add(x => x.ID, -1);
             await connector.DeleteAsync(filter);
 

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentListTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentListTests.cs
@@ -755,7 +755,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -773,7 +773,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentList>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentListVersionTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentListVersionTests.cs
@@ -440,7 +440,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -458,7 +458,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentListVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentTargetTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentTargetTests.cs
@@ -403,7 +403,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -421,7 +421,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTarget>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentTemplateTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentTemplateTests.cs
@@ -650,7 +650,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -668,7 +668,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentTests.cs
@@ -652,7 +652,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -670,7 +670,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Component>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/ComponentVersionTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/ComponentVersionTests.cs
@@ -659,7 +659,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -677,7 +677,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<ComponentVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/CountryTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/CountryTests.cs
@@ -350,7 +350,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -368,7 +368,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Country>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/FolderTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/FolderTests.cs
@@ -674,7 +674,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -692,7 +692,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Folder>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/GalleryTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/GalleryTests.cs
@@ -984,7 +984,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -1002,7 +1002,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Gallery>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/InstallerTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/InstallerTests.cs
@@ -262,7 +262,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -280,7 +280,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Installer>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/LinkTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/LinkTests.cs
@@ -120,7 +120,7 @@ namespace Sushi.Mediakiwi.Test.ORM
             // Get all test records, we will delete them ALL
             // Link does not contain a SelectAll(), Replace code below when SelectAll() is added.
             var connector = ConnectorFactory.CreateConnector<Link>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var allAssert = connector.FetchAll(filter).ToArray();
             var ass = allAssert.Where(x => x.Target == _TestObj.Target);
             if (ass.Count() == 0)
@@ -153,7 +153,7 @@ namespace Sushi.Mediakiwi.Test.ORM
             // Get all test records, we will delete them ALL
             // Link does not contain a SelectAllAsync(), Replace code below when SelectAllAsync() is added.
             var connector = ConnectorFactory.CreateConnector<Link>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
             var allAssert = await connector.FetchAllAsync(filter);
             var ass = allAssert.ToArray().Where(x => x.Target == _TestObjAsync.Target);
             if (ass.Count() == 0)
@@ -184,7 +184,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Link>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -202,7 +202,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Link>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/MenuItemTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/MenuItemTests.cs
@@ -234,7 +234,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -252,7 +252,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<MenuItem>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/MenuTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/MenuTests.cs
@@ -206,7 +206,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Menu>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -224,7 +224,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Menu>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/NotificationTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/NotificationTests.cs
@@ -722,7 +722,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Data.Sql.Notification>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -740,7 +740,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Data.Sql.Notification>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PageMappingTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PageMappingTests.cs
@@ -311,7 +311,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -329,7 +329,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageMapping>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PageTemplateTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PageTemplateTests.cs
@@ -439,7 +439,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -457,7 +457,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageTemplate>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PageTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PageTests.cs
@@ -1069,7 +1069,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -1087,7 +1087,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Page>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PageVersionTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PageVersionTests.cs
@@ -237,7 +237,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PageVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -255,7 +255,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PageVersion>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PortalRightTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PortalRightTests.cs
@@ -241,7 +241,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -259,7 +259,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PortalTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PortalTests.cs
@@ -326,7 +326,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Mediakiwi.Data.Portal>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -344,7 +344,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector< Mediakiwi.Data.Portal >();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PropertyOptionTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PropertyOptionTests.cs
@@ -266,7 +266,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -284,7 +284,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PropertySearchColumnTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PropertySearchColumnTests.cs
@@ -282,7 +282,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -300,7 +300,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/PropertyTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/PropertyTests.cs
@@ -329,7 +329,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -347,7 +347,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<PortalRight>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/SiteTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/SiteTests.cs
@@ -497,7 +497,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -515,7 +515,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Site>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";

--- a/test/Sushi.Mediakiwi.Test/ORM/VisitorTests.cs
+++ b/test/Sushi.Mediakiwi.Test/ORM/VisitorTests.cs
@@ -288,7 +288,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public void F_Reset_AutoIndent()
         {
             var connector = ConnectorFactory.CreateConnector<Visitor>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";
@@ -306,7 +306,7 @@ namespace Sushi.Mediakiwi.Test.ORM
         public async Task F_Reset_AutoIndentAsync()
         {
             var connector = ConnectorFactory.CreateConnector<Visitor>();
-            var filter = connector.CreateDataFilter();
+            var filter = connector.CreateQuery();
 
             // Query for resetting the autoincrement in the table
             string sql = $"DECLARE @max int;  SELECT @max = ISNULL(MAX([{_key}]), 1) FROM [dbo].[{_table}];  DBCC CHECKIDENT({_table}, RESEED, @max)";


### PR DESCRIPTION
The following changes are in this PR:

- The AccessRules are now checked AFTER the root page has been determined.
- Obsolete Sushi.MicroORM methods were replaced
- Added redirect check, so it happens only when the URL is different than the current one, preventing infinite redirect loops

