### PR TITLE
Bug/various fixes 2022 01 24

### DIFF
--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>
+    <Version>8.1.10</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>
+    <Version>8.1.10</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Data/Field.cs
+++ b/src/Sushi.Mediakiwi.Data/Data/Field.cs
@@ -88,7 +88,7 @@ namespace Sushi.Mediakiwi.Data
                         try
                         {
                             DateTime dt;
-                            if (DateTime.TryParse(Value, dateInfo.culture, System.Globalization.DateTimeStyles.None, out dt))
+                            if (DateTime.TryParseExact(Value, dateInfo.dateTimeFormat, dateInfo.culture, System.Globalization.DateTimeStyles.None, out dt))
                             {
                                 return dt;
                             }

--- a/src/Sushi.Mediakiwi.Data/Repositories/Sql/NotificationRepository.cs
+++ b/src/Sushi.Mediakiwi.Data/Repositories/Sql/NotificationRepository.cs
@@ -139,9 +139,11 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         public sql.Notification[] SelectAll(string group, int selection, int? maxResult)
         {   
             var filter = connector.CreateQuery();
-            filter.AddOrder(x => x.ID);
+            filter.AddOrder(x => x.ID, Sushi.MicroORM.SortOrder.DESC);
             if (maxResult.GetValueOrDefault(0) > 0)
+            {
                 filter.MaxResults = maxResult.Value;
+            }
 
             filter.Add(x => x.Group, group);
             filter.Add(x => x.Selection, selection);
@@ -162,11 +164,13 @@ namespace Sushi.Mediakiwi.Data.Repositories.Sql
         public async Task<sql.Notification[]> SelectAllAsync(string group, int selection, int? maxResult)
         {   
             var filter = connector.CreateQuery();
-            filter.AddOrder(x => x.ID);
+            filter.AddOrder(x => x.ID, Sushi.MicroORM.SortOrder.DESC);
             filter.Add(x => x.Group, group);
             filter.Add(x => x.Selection, selection);
             if (maxResult.GetValueOrDefault(0) > 0)
+            {
                 filter.MaxResults = maxResult.Value;
+            }
 
             var result = await connector.FetchAllAsync(filter).ConfigureAwait(false);
             return result.ToArray();

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>
+    <Version>8.1.10</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Utility.cs
+++ b/src/Sushi.Mediakiwi.Data/Utility.cs
@@ -1119,12 +1119,14 @@ namespace Sushi.Mediakiwi.Data
         /// <returns></returns>
         public static DateTime ConvertWimDateTime(object candidate)
         {
+            var dateInfo = Mediakiwi.Common.GetDateInformation();
+
             if (candidate == null || candidate.ToString().Length == 0)
             {
                 return DateTime.MinValue;
             }
 
-            if (DateTime.TryParse(candidate.ToString(), WimCultureInfo, DateTimeStyles.None, out DateTime dt))
+            if (DateTime.TryParseExact(candidate.ToString(), dateInfo.dateTimeFormat, dateInfo.culture, DateTimeStyles.None, out DateTime dt))
             {
                 return dt;
             }

--- a/src/Sushi.Mediakiwi.Demonstration/appsettings.json
+++ b/src/Sushi.Mediakiwi.Demonstration/appsettings.json
@@ -41,7 +41,7 @@
     "stylesheet": "/styles/override.css?20201101",
     "append_stylesheet": true,
     "disable_caching": false,
-    "local_file_path": "https://localhost/Sushi.Mediakiwi.Files/",
+   // "local_file_path": "https://localhost/Sushi.Mediakiwi.Files/",
     "file_version": null,
     "azure_image_container": "testing-mediakiwi",
     "sql_install_enabled": true,

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>
+    <Version>8.1.10</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>
+    <Version>8.1.10</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi/Framework/ContentInfoItem/DateAttribute.cs
+++ b/src/Sushi.Mediakiwi/Framework/ContentInfoItem/DateAttribute.cs
@@ -95,7 +95,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                         {
                             //  Previous WIM versions
                             DateTime tmp;
-                            if (DateTime.TryParse(field.Value, Console.DateCulture, DateTimeStyles.None, out tmp))
+                            if (DateTime.TryParseExact(field.Value, Console.DateFormat, Console.DateCulture, DateTimeStyles.None, out tmp))
                             {
                                 m_Candidate = tmp;
                             }
@@ -134,7 +134,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                     {
                         string candidate = Console.Form(ID);
                         DateTime tmp;
-                        if (DateTime.TryParse(candidate, Console.DateCulture, DateTimeStyles.None, out tmp))
+                        if (DateTime.TryParseExact(candidate, Console.DateFormat, Console.DateCulture, DateTimeStyles.None, out tmp))
                         {
                             m_Candidate = tmp;
                         }
@@ -184,7 +184,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                 {
                     //  Previous WIM versions
                     DateTime tmp;
-                    if (DateTime.TryParse(field.InheritedValue, Console.DateCulture, DateTimeStyles.None, out tmp))
+                    if (DateTime.TryParseExact(field.InheritedValue, Console.DateFormat, Console.DateCulture, DateTimeStyles.None, out tmp))
                     {
                         InhertitedOutputText = tmp.ToString(Console.DateFormat, Console.DateCulture);
                     }

--- a/src/Sushi.Mediakiwi/Framework/ContentInfoItem/DateTimeAttribute.cs
+++ b/src/Sushi.Mediakiwi/Framework/ContentInfoItem/DateTimeAttribute.cs
@@ -129,7 +129,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                         {
                             //  Previous WIM versions
                             DateTime tmp;
-                            if (DateTime.TryParse(field.Value, dateInfo.culture, DateTimeStyles.None, out tmp))
+                            if (DateTime.TryParseExact(field.Value, dateInfo.dateTimeFormat, dateInfo.culture, DateTimeStyles.None, out tmp))
                             {
                                 m_Candidate = tmp;
                             }
@@ -170,7 +170,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                     {
                         string candidate = Console.Form(ID);
                         DateTime tmp;
-                        if (DateTime.TryParse(candidate, dateInfo.culture, DateTimeStyles.None, out tmp))
+                        if (DateTime.TryParseExact(candidate, dateInfo.dateFormat, dateInfo.culture, DateTimeStyles.None, out tmp))
                         {
                             if (!string.IsNullOrEmpty(Console.Form(ID + "T")))
                             {
@@ -226,7 +226,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                 {
                     //  Previous WIM versions
                     DateTime tmp;
-                    if (DateTime.TryParse(field.InheritedValue, dateInfo.culture, DateTimeStyles.None, out tmp))
+                    if (DateTime.TryParseExact(field.InheritedValue, dateInfo.dateTimeFormat, dateInfo.culture, DateTimeStyles.None, out tmp))
                     {
                         InhertitedOutputText = tmp.ToString(dateInfo.dateTimeFormat, dateInfo.culture);
                     }

--- a/src/Sushi.Mediakiwi/Framework/ContentListItem/FileUploadAttribute.cs
+++ b/src/Sushi.Mediakiwi/Framework/ContentListItem/FileUploadAttribute.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Sushi.Mediakiwi.Data;
 using System;
 using System.Threading.Tasks;
@@ -85,7 +86,9 @@ namespace Sushi.Mediakiwi.Framework.ContentListItem
         {
             m_Candidate = null;
             if (Context.Request.HasFormContentType && Context.Request.Form.Files.Count > 0)
+            {
                 m_Candidate = new FileUpload(Context.Request.Form.Files[ID]);
+            }
 
             //  Possible return types: System.Web.HttpPostedFile
 
@@ -160,10 +163,14 @@ namespace Sushi.Mediakiwi.Framework.ContentListItem
             {
                 //  Custom error validation
                 if (!base.IsValid(isRequired))
+                {
                     return false;
+                }
 
                 if (Mandatory && (m_Candidate == null || m_Candidate.File.Length == 0))
+                {
                     return false;
+                }
             }
             return true;
         }

--- a/src/Sushi.Mediakiwi/Framework/Templates/PropertySet.cs
+++ b/src/Sushi.Mediakiwi/Framework/Templates/PropertySet.cs
@@ -132,6 +132,8 @@ namespace Sushi.Mediakiwi.Framework.Templates
         /// <returns></returns>
         public bool SetValue(Site site, object loadedControl, Content content, Component component, Page callingPage)
         {
+            var dateInfo = Common.GetDateInformation();
+
             bool isInheritedContent = false;
             if ( callingPage != null && callingPage.InheritContent )
                 isInheritedContent = true;
@@ -147,7 +149,7 @@ namespace Sushi.Mediakiwi.Framework.Templates
             }
 
             System.Globalization.CultureInfo cultureInfo = new System.Globalization.CultureInfo("nl-NL");
-
+            
             RichLink rlink = new RichLink(site);
 
             // 18-10-2020:MM
@@ -314,7 +316,7 @@ namespace Sushi.Mediakiwi.Framework.Templates
                                         }
                                         else
                                         {
-                                            if (DateTime.TryParse(itemValue.ToString(), cultureInfo, System.Globalization.DateTimeStyles.None, out dtResult))
+                                            if (DateTime.TryParseExact(itemValue.ToString(), dateInfo.dateTimeFormat, dateInfo.culture, System.Globalization.DateTimeStyles.None, out dtResult))
                                             {
                                                 dtResult = ConvertDateTimeToLocal(loadedControl, dtResult);
                                                 info.SetValue(loadedControl, dtResult, null);

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.9</Version>    
+    <Version>8.1.10</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/src/Sushi.Mediakiwi/UI/Monitor.cs
+++ b/src/Sushi.Mediakiwi/UI/Monitor.cs
@@ -1468,7 +1468,7 @@ namespace Sushi.Mediakiwi.UI
             if (!string.IsNullOrWhiteSpace(name))
             {
                 var urldecrypt = Utils.FromUrl(name);
-                var list = await ComponentList.SelectOneAsync(urldecrypt, null).ConfigureAwait(false);
+                var list = await ComponentList.SelectOneAsync(urldecrypt, folderId).ConfigureAwait(false);
                 if (list != null && !list.IsNewInstance)
                 {
                     return await _Console.ApplyListAsync(list).ConfigureAwait(false);

--- a/src/Sushi.Mediakiwi/Utils.cs
+++ b/src/Sushi.Mediakiwi/Utils.cs
@@ -1962,12 +1962,14 @@ namespace Sushi.Mediakiwi
 		/// <returns></returns>
 		public static DateTime ConvertWimDateTime(object candidate)
 		{
+            var dateInfo = Common.GetDateInformation();
+
 			if (candidate == null || candidate.ToString().Length == 0)
 			{
 				return DateTime.MinValue;
 			}
 
-			if (DateTime.TryParse(candidate.ToString(), WimCultureInfo, DateTimeStyles.None, out DateTime dt))
+			if (DateTime.TryParseExact(candidate.ToString(), dateInfo.dateTimeFormat, dateInfo.culture, DateTimeStyles.None, out DateTime dt))
 			{
 				return dt;
 			}


### PR DESCRIPTION
This PR contains the following changes & fixes:

- When resolving a list URL based on it's name, the residing folder is also taken into account.
- DateTime parsing is now using `TryParseExact `instead of `TryParse `to accomodate the changes made to datetime formatting.
- Notifications (based on SQL repository) are now sorted by ID Descending, instead of ID Ascending.