### PR TITLE
Added API Only listdatacolumntype

### DIFF
--- a/src/Sushi.Mediakiwi.API/Services/ContentService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/ContentService.cs
@@ -106,7 +106,8 @@ namespace Sushi.Mediakiwi.API.Services
             {
                 ListDataColumnType.Highlight,
                 ListDataColumnType.UniqueHighlightedIdentifier,
-                ListDataColumnType.UniqueIdentifier
+                ListDataColumnType.UniqueIdentifier,
+                ListDataColumnType.APIOnly
             };
 
             #region Columns

--- a/src/Sushi.Mediakiwi.Demonstration/Data/DemoObject1.cs
+++ b/src/Sushi.Mediakiwi.Demonstration/Data/DemoObject1.cs
@@ -2,6 +2,7 @@
 using Sushi.MicroORM.Mapping;
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Sushi.Mediakiwi.Demonstration.Data
@@ -27,6 +28,16 @@ namespace Sushi.Mediakiwi.Demonstration.Data
         public string Group { get; set; }
         public DateTime Created { get; set; }
         public DateTime? Updated { get; set; }
+
+
+        [JsonIgnore]
+        public string JSON
+        {
+            get
+            {
+                return System.Text.Json.JsonSerializer.Serialize(this);
+            }
+        }
         
         public static async Task<List<DemoObject1>> FetchAllAsync()
         {

--- a/src/Sushi.Mediakiwi.Demonstration/Templates/List/DemoList1.cs
+++ b/src/Sushi.Mediakiwi.Demonstration/Templates/List/DemoList1.cs
@@ -29,9 +29,20 @@ namespace Sushi.Mediakiwi.Demonstration.Templates.List
             ListSave += DemoList1_ListSave;
             ListDelete += DemoList1_ListDelete;
             ListDataReceived += DemoList1_ListDataReceived;
+            ListDataItemCreated += DemoList1_ListDataItemCreated;
         }
 
- 
+        private void DemoList1_ListDataItemCreated(object sender, ListDataItemCreatedEventArgs e)
+        {
+            if (e.Item is Data.DemoObject1 item && e.Type == DataItemType.TableCell)
+            {
+                if (e.ColumnProperty == nameof(Data.DemoObject1.ID))
+                {
+                    e.Attribute.Add("Something", $"dinges_{item.ID}");
+                }
+            }
+        }
+
         private async Task DemoList1_ListDataReceived(Framework.EventArguments.ComponentListDataReceived arg)
         {
             if (string.IsNullOrWhiteSpace(arg.FullTypeName) == false)
@@ -179,6 +190,7 @@ namespace Sushi.Mediakiwi.Demonstration.Templates.List
             
             wim.ListDataColumns.Add(new ListDataColumn("ID", nameof(Data.DemoObject1.ID), ListDataColumnType.UniqueIdentifier));
             wim.ListDataColumns.Add(new ListDataColumn("Title", nameof(Data.DemoObject1.Title), ListDataColumnType.HighlightPresent));
+            wim.ListDataColumns.Add(new ListDataColumn("JSON", nameof(Data.DemoObject1.JSON), ListDataColumnType.APIOnly));
             wim.ListDataColumns.Add(new ListDataColumn("Group", nameof(Data.DemoObject1.Group), ListDataColumnType.Default));
             wim.ListDataColumns.Add(new ListDataColumn("Created", nameof(Data.DemoObject1.Created), ListDataColumnType.Default) { ColumnWidth = 90 });
             wim.ListDataColumns.Add(new ListDataColumn("Updated", nameof(Data.DemoObject1.Updated), ListDataColumnType.Default) { ColumnWidth = 90 });

--- a/src/Sushi.Mediakiwi/Framework/ListDataColumnType.cs
+++ b/src/Sushi.Mediakiwi/Framework/ListDataColumnType.cs
@@ -9,51 +9,67 @@
         /// This is a default data column
         /// </summary>
         Default = 0,
+
         /// <summary>
         /// This column defines the unique identier used in ComponentListEventArgs.
         /// The column doesn't show in the presented list.
         /// </summary>
         UniqueIdentifier = 1,
+
         /// <summary>
         /// This column defines the unique identier used in ComponentListEventArgs.
         /// The column shows up in the the presented list.
         /// </summary>
         UniqueIdentifierPresent = 2,
+
         /// <summary>
         /// This column defines the unique identier used in ComponentListEventArgs and also shows up as human readable reference in derived lists.
         /// The column doesn't show in the presented list.
         /// </summary>
         UniqueHighlightedIdentifier = 3,
+
         /// <summary>
         /// This column defines the unique identier used in ComponentListEventArgs and also shows up as human readable reference in derived lists.
         /// The column shows up in the the presented list.
         /// </summary>
         UniqueHighlightedIdentifierPresent = 4,
+
         /// <summary>
         /// This column shows up as human readable reference in derived lists.
         /// The column doesn't show in the presented list.
         /// </summary>
         Highlight = 5,
+
         /// <summary>
         /// This column shows up as human readable reference in derived lists.
         /// The column shows up in the the presented list.
         /// </summary>
         HighlightPresent = 6,
+
         /// <summary>
         /// This columns is only exposed for export.
         /// </summary>
         ExportOnly = 7,
+
         /// <summary>
         /// Return a checkbox item with the columnpropertyname as id.
         /// </summary>
         Checkbox = 8 ,
+
         /// <summary>
         /// Return a checkbox item with the columnpropertyname as id.
         /// </summary>
         RadioBox = 9,
+
         /// <summary>
         /// The view only
         /// </summary>
-        ViewOnly = 10
+        ViewOnly = 10,
+
+        /// <summary>
+        /// Will only be rendered to the API output.
+        /// The column doesn't show in the presented list.
+        /// </summary>
+        APIOnly = 11
     }
 }

--- a/src/Sushi.Mediakiwi/UI/DataGrid.cs
+++ b/src/Sushi.Mediakiwi/UI/DataGrid.cs
@@ -803,7 +803,8 @@ namespace Sushi.Mediakiwi.UI
                             col.Type == ListDataColumnType.ExportOnly 
                             || col.Type == ListDataColumnType.Highlight 
                             || col.Type == ListDataColumnType.UniqueIdentifier 
-                            || col.Type == ListDataColumnType.UniqueHighlightedIdentifier);
+                            || col.Type == ListDataColumnType.UniqueHighlightedIdentifier
+                            || col.Type == ListDataColumnType.APIOnly);
 
                         if (col.ColumnWidth == 0 && !isHidden)
                             throw new Exception(string.Format("When applying scrolling all columns should have a fixed with. This is not set for '{0}'", col.ColumnValuePropertyName));
@@ -2876,7 +2877,8 @@ namespace Sushi.Mediakiwi.UI
             if (type == ListDataColumnType.ExportOnly ||
                 type == ListDataColumnType.Highlight ||
                 type == ListDataColumnType.UniqueHighlightedIdentifier ||
-                type == ListDataColumnType.UniqueIdentifier)
+                type == ListDataColumnType.UniqueIdentifier ||
+                type == ListDataColumnType.APIOnly)
                 return false;
 
             return true;


### PR DESCRIPTION
This column will not show up in the normal list, but will be added to the MKAPI output.
This is needed so that the API consumer can determine what to do with the supplied information in that column.