### PR TITLE
When a listmodule is triggered, add the redirect URL to API output

### DIFF
--- a/src/Sushi.Mediakiwi.API/Services/ContentService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/ContentService.cs
@@ -1035,7 +1035,7 @@ namespace Sushi.Mediakiwi.API.Services
 
             if (_resolver.ListInstance?.wim?.Console?.Request?.HttpContext?.RequestServices?.GetServices<IListModule>().Any() == true)
             {
-                listModules = _resolver.ListInstance?.wim?.Console?.Request?.HttpContext?.RequestServices?.GetServices<IListModule>().ToList();
+                listModules = _resolver.ListInstance.wim.Console.Request.HttpContext.RequestServices.GetServices<IListModule>().ToList();
 
                 // Remove modules that shouldnt be in the corresponding List State
                 if (_resolver.ListInstance.wim.IsEditMode)

--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>
+    <Version>8.1.34</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.API/UrlResolver.cs
+++ b/src/Sushi.Mediakiwi.API/UrlResolver.cs
@@ -610,7 +610,7 @@ namespace Sushi.Mediakiwi.API
                                 || ItemID.GetValueOrDefault(-1) == 0
                                 || ItemObject != null
                                 || AssetID.GetValueOrDefault(-1) == 0
-                                || (_console.JsonReferrer != null && _console.JsonReferrer.Equals("edit"))
+                                || (_console.JsonReferrer != null && _console.JsonReferrer.Equals("edit", StringComparison.InvariantCultureIgnoreCase))
                                 || _console.JsonForm != null;
 
 
@@ -621,9 +621,9 @@ namespace Sushi.Mediakiwi.API
                             m_instance.wim.IsDeleteMode = isDeletePostBack;
                         }
                         // Determine Edit state when we don't have an explicit Item
-                        else if (m_instance.wim.OpenInEditMode && m_instance.wim.CanContainSingleInstancePerDefinedList)
+                        else if (m_instance.wim.CanContainSingleInstancePerDefinedList)
                         {
-                            m_instance.wim.IsEditMode = true;
+                            m_instance.wim.IsEditMode = m_instance.wim.OpenInEditMode || isEditPostBack;
 
                             // Is the form in Save Mode
                             m_instance.wim.IsSaveMode = isSavePostBack;

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>
+    <Version>8.1.34</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>
+    <Version>8.1.34</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>
+    <Version>8.1.34</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>
+    <Version>8.1.34</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.33</Version>    
+    <Version>8.1.34</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>


### PR DESCRIPTION
Since ListModules don't follow the normal PostBack flow, an addition was to be made to the MKAPI.
so now when a listmodule is triggered to the MKAPI, the redirect URL wil output to the API.