### PR TITLE
Allows the API to readout the state of SearchButtons

### DIFF
--- a/src/Sushi.Mediakiwi.API/Services/ContentService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/ContentService.cs
@@ -252,13 +252,39 @@ namespace Sushi.Mediakiwi.API.Services
             {
                 var buttonAttribute = item.GetCustomAttribute<Framework.ContentListSearchItem.ButtonAttribute>();
                 if (buttonAttribute != null)
-                { 
+                {
+                    // Determine visibility
+                    var isVisible = buttonAttribute.IsHidden == false;
+                    if (_resolver?.ListInstance?.wim?.VisibilityList?.Any(x => x.AssignedProperty == item.Name) == true)
+                    {
+                        isVisible = _resolver.ListInstance.wim.VisibilityList.First(x => x.AssignedProperty == item.Name).State;
+                    }
+
+                    // Determine editable
+                    var isEditable = buttonAttribute.IsReadOnly == false;
+                    if (_resolver?.ListInstance?.wim?.EditableList?.Any(x => x.AssignedProperty == item.Name) == true)
+                    {
+                        isEditable = _resolver.ListInstance.wim.EditableList.First(x => x.AssignedProperty == item.Name).State;
+                    }
+
+                    // Determine required
+                    var isRequired = buttonAttribute.Mandatory;
+                    if (_resolver?.ListInstance?.wim?.RequiredList?.Any(x => x.AssignedProperty == item.Name) == true)
+                    {
+                        isRequired = _resolver.ListInstance.wim.RequiredList.First(x => x.AssignedProperty == item.Name).State;
+                    }
+
+                    buttonAttribute.IsReadOnly = !isEditable;
+                    buttonAttribute.Mandatory = isRequired;
+                    buttonAttribute.IsHidden = !isVisible;
+
                     var newButton = await GetButtonAsync(buttonAttribute);
                     newButton.FormSection = grid.Title;
                     newButton.PropertyName = item.Name;
                     newButton.PropertyType = item.PropertyType.FullName;
 
                     grid.Buttons.Add(newButton);
+
                 }
             }
 

--- a/src/Sushi.Mediakiwi/Framework/WimComponentListRoot.cs
+++ b/src/Sushi.Mediakiwi/Framework/WimComponentListRoot.cs
@@ -1502,7 +1502,7 @@ namespace Sushi.Mediakiwi.Framework
         /// <summary>
         /// 
         /// </summary>
-        internal class StateTypeItem
+        public class StateTypeItem
         {
             /// <summary>
             /// Gets or sets the assigned property.
@@ -1692,6 +1692,15 @@ namespace Sushi.Mediakiwi.Framework
         }
 
         internal List<StateTypeItem> VisibilityItemList;
+
+        public IReadOnlyList<StateTypeItem> VisibilityList
+        {
+            get
+            {
+                return VisibilityItemList;
+            }
+        }
+
         /// <summary>
         /// Sets the property visibility.
         /// </summary>
@@ -1739,6 +1748,14 @@ namespace Sushi.Mediakiwi.Framework
         }
 
         internal List<StateTypeItem> RequiredItemList;
+        public IReadOnlyList<StateTypeItem> RequiredList
+        {
+            get
+            {
+                return RequiredItemList;
+            }
+        }
+
         /// <summary>
         /// Sets the property required.
         /// </summary>
@@ -1783,6 +1800,14 @@ namespace Sushi.Mediakiwi.Framework
         }
 
         internal List<StateTypeItem> EditableItemList;
+        public IReadOnlyList<StateTypeItem> EditableList
+        {
+            get
+            {
+                return EditableItemList;
+            }
+        }
+
         /// <summary>
         /// Sets the property editable.
         /// </summary>


### PR DESCRIPTION
Whenever the state of a button is set in the ListSearch, for example for visibility this didn't reflect to the API returned buttons. with this fix it does