### PR TITLE
Some additional logout logic added

### DIFF
--- a/src/Sushi.Mediakiwi.API/Services/UserService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/UserService.cs
@@ -109,14 +109,17 @@ namespace Sushi.Mediakiwi.API.Services
 
         public async Task LogoutAsync()
         {
-            // Remove cookie
+            // Clear cookie values
             var visManager = new VisitorManager(_httpAccessor.HttpContext);
             var visitor = await visManager.SelectAsync();
             visitor.ProfileID = null;
+            visitor.ApplicationUserID = null;
+            visitor.Jwt = null;
+
             await visManager.SaveAsync(visitor);
             await visitor.SaveAsync();
 
-            await _httpAccessor.HttpContext.SignOutAsync().ConfigureAwait(false);
+            await _httpAccessor.HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme).ConfigureAwait(false);
         }
 
         public async Task<LoginResponse> LoginAsync(LoginRequest request)
@@ -158,7 +161,7 @@ namespace Sushi.Mediakiwi.API.Services
             // Set cookie
             var visManager = new VisitorManager(_httpAccessor.HttpContext);
             var visitor = await visManager.SelectAsync();
-            visitor.ProfileID = user.ID;
+            visitor.ApplicationUserID = user.ID;
             await visManager.SaveAsync(visitor);
 
             return new LoginResponse()

--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>
+    <Version>8.1.44</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>
+    <Version>8.1.44</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>
+    <Version>8.1.44</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>
+    <Version>8.1.44</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>
+    <Version>8.1.44</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi/Identity/VisitorManager.cs
+++ b/src/Sushi.Mediakiwi/Identity/VisitorManager.cs
@@ -222,8 +222,8 @@ namespace Sushi.Mediakiwi
                     return false;
                 }
 
-                //  If there is no data, and no profile details to be stored, why should we save the record?
-                if ((entity.Data == null || entity.Data.Serialized == null) && !entity.ProfileID.HasValue)
+                //  If there is no data, no profile details and no appuser to be stored, why should we save the record?
+                if ((entity.Data == null || entity.Data.Serialized == null) && !entity.ProfileID.HasValue && !entity.ApplicationUserID.HasValue)
                 {
                     return false;
                 }

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.43</Version>    
+    <Version>8.1.44</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/src/Sushi.Mediakiwi/UI/Monitor.cs
+++ b/src/Sushi.Mediakiwi/UI/Monitor.cs
@@ -26,6 +26,8 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Sushi.Mediakiwi.Framework.Interfaces;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace Sushi.Mediakiwi.UI
 {
@@ -1591,6 +1593,7 @@ namespace Sushi.Mediakiwi.UI
                 if (_Console.IsPostBack("logout") || _Console.Request.Query.ContainsKey("logout"))
                 {
                     await LogoutViaSingleSignOnAsync().ConfigureAwait(false);
+                    await LogoutIdentityAsync().ConfigureAwait(false);
                 }
             }
 
@@ -1656,12 +1659,21 @@ namespace Sushi.Mediakiwi.UI
             }
         }
 
+        async Task LogoutIdentityAsync()
+        {
+            // Check if we have a context User signed in
+            if (_Context?.User?.Identity?.IsAuthenticated == true)
+            {
+                await _Context.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme).ConfigureAwait(false);
+            }
+        }
+
         async Task LogoutViaSingleSignOnAsync()
         {
             _Console.CurrentVisitor.ApplicationUserID = null;
             _Console.CurrentVisitor.Jwt = null;
             await _Console.CurrentVisitor.SaveAsync().ConfigureAwait(false);
-
+      
             if (_configuration.GetValue<bool>("mediakiwi:authentication"))
             {
                 _Context.Response.Redirect($"{_Console.CurrentDomain}/.auth/logout?post_logout_redirect_uri={_Console.GetWimPagePath(null)}");


### PR DESCRIPTION
The following was added when logging out:
1. MK: Also logout the Context User Identity when there's one logged in.
2. MKAPI: Clear the ApplicationUser and Jwt fields from the visitor.

The following was changed when logging in:
1. The userid was set to the ProfileID field, this is corrected to the ApplicationUserID field