### PR TITLE
Extended the Image field to the API

### DIFF
--- a/src/Sushi.Mediakiwi.API/Services/ContentService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/ContentService.cs
@@ -683,61 +683,6 @@ namespace Sushi.Mediakiwi.API.Services
                 VueType = ConvertEnum(field.VueType)
             };
 
-            //// An Image is treated differently, because we're showing multiple
-            //// parts of information 
-            //if (field.ContentTypeID == Data.ContentType.Binary_Image)
-            //{
-            //    newField.PropertyType = typeof(string).FullName;
-
-            //    int? currentAssetId = null;
-            //    if (_resolver.ListInstance != null)
-            //    {
-            //        var prop = _resolver.ListInstance.GetType().GetProperty(field.PropertyName);
-            //        if (prop != null)
-            //        {
-            //            var _value = prop.GetValue(_resolver.ListInstance, null);
-            //            if (_value is int)
-            //            {
-            //                currentAssetId = (int)_value;
-            //            }
-            //            else if (_value is int?)
-            //            {
-            //                currentAssetId = (int?)_value;
-            //            }
-            //        }
-            //    }
-
-            //    AssetInfoJson info = new();
-
-            //    if (currentAssetId.GetValueOrDefault(0) > 0)
-            //    {
-            //        var currentAsset = await Data.Asset.SelectOneAsync(currentAssetId.Value);
-            //        if (currentAsset?.ID > 0)
-            //        {
-            //            info = new()
-            //            {
-            //                Title = currentAsset.Title,
-            //                FileSize = currentAsset.Size,
-            //                GalleryID = currentAsset.GalleryID,
-            //                Height = currentAsset.Height,
-            //                Width = currentAsset.Width,
-            //                ID = currentAsset.ID,
-            //                URL = currentAsset.RemoteLocation,
-            //                Description = currentAsset.Description
-            //            };
-            //        }
-            //    }
-
-            //    var options = new System.Text.Json.JsonSerializerOptions
-            //    {
-            //        PropertyNameCaseInsensitive = true,
-            //        IgnoreReadOnlyProperties = true,
-            //        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
-            //    };
-
-            //    newField.Value = System.Text.Json.JsonSerializer.Serialize<AssetInfoJson>(info, options);
-            //}
-
             if (field.Value is ICollection<string> stringCol)
             {
                 newField.Value = string.Join(',', stringCol);

--- a/src/Sushi.Mediakiwi.API/Services/ContentService.cs
+++ b/src/Sushi.Mediakiwi.API/Services/ContentService.cs
@@ -654,7 +654,7 @@ namespace Sushi.Mediakiwi.API.Services
 
         #region Get Field
 
-        private ContentField GetField(Framework.Api.MediakiwiField field)
+        private async Task<ContentField> GetFieldAsync(Framework.Api.MediakiwiField field)
         {
             var newField = new ContentField()
             {
@@ -682,6 +682,61 @@ namespace Sushi.Mediakiwi.API.Services
                 Value = (field.Value != null) ? field.Value.ToString() : "",
                 VueType = ConvertEnum(field.VueType)
             };
+
+            //// An Image is treated differently, because we're showing multiple
+            //// parts of information 
+            //if (field.ContentTypeID == Data.ContentType.Binary_Image)
+            //{
+            //    newField.PropertyType = typeof(string).FullName;
+
+            //    int? currentAssetId = null;
+            //    if (_resolver.ListInstance != null)
+            //    {
+            //        var prop = _resolver.ListInstance.GetType().GetProperty(field.PropertyName);
+            //        if (prop != null)
+            //        {
+            //            var _value = prop.GetValue(_resolver.ListInstance, null);
+            //            if (_value is int)
+            //            {
+            //                currentAssetId = (int)_value;
+            //            }
+            //            else if (_value is int?)
+            //            {
+            //                currentAssetId = (int?)_value;
+            //            }
+            //        }
+            //    }
+
+            //    AssetInfoJson info = new();
+
+            //    if (currentAssetId.GetValueOrDefault(0) > 0)
+            //    {
+            //        var currentAsset = await Data.Asset.SelectOneAsync(currentAssetId.Value);
+            //        if (currentAsset?.ID > 0)
+            //        {
+            //            info = new()
+            //            {
+            //                Title = currentAsset.Title,
+            //                FileSize = currentAsset.Size,
+            //                GalleryID = currentAsset.GalleryID,
+            //                Height = currentAsset.Height,
+            //                Width = currentAsset.Width,
+            //                ID = currentAsset.ID,
+            //                URL = currentAsset.RemoteLocation,
+            //                Description = currentAsset.Description
+            //            };
+            //        }
+            //    }
+
+            //    var options = new System.Text.Json.JsonSerializerOptions
+            //    {
+            //        PropertyNameCaseInsensitive = true,
+            //        IgnoreReadOnlyProperties = true,
+            //        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase
+            //    };
+
+            //    newField.Value = System.Text.Json.JsonSerializer.Serialize<AssetInfoJson>(info, options);
+            //}
 
             if (field.Value is ICollection<string> stringCol)
             {
@@ -749,7 +804,7 @@ namespace Sushi.Mediakiwi.API.Services
             ButtonField newButton = new ButtonField();
 
             // Get all standard Field content
-            ContentField result = GetField(field);
+            ContentField result = await GetFieldAsync(field);
 
             // Copy all field Content to button            
             Utils.ReflectProperty(result, newButton);
@@ -1109,7 +1164,7 @@ namespace Sushi.Mediakiwi.API.Services
                             }
                             else if (field.ContentTypeID == Data.ContentType.DataList)
                             {
-                                var newField = GetField(field);
+                                var newField = await GetFieldAsync(field);
 
                                 // Get property
                                 var prop = _resolver.ListInstance.GetType().GetProperty(field.PropertyName);
@@ -1135,7 +1190,7 @@ namespace Sushi.Mediakiwi.API.Services
                             }
                             else 
                             {
-                                var newField = GetField(field);
+                                var newField = await GetFieldAsync(field);
                                 if (newField == null)
                                 {
                                     continue;
@@ -1199,7 +1254,7 @@ namespace Sushi.Mediakiwi.API.Services
                             ci.SenderInstance = _resolver.ListInstance;
                             var apiField = await ci.GetApiFieldAsync();
 
-                            formMap.Fields.Add(GetField(apiField));
+                            formMap.Fields.Add(await GetFieldAsync(apiField));
                         }
                     }
                 }
@@ -1221,7 +1276,7 @@ namespace Sushi.Mediakiwi.API.Services
                         mapElement.SenderInstance = _resolver.ListInstance;
                         var apiField = await mapElement.GetApiFieldAsync();
 
-                        formMap.Fields.Add(GetField(apiField));
+                        formMap.Fields.Add(await GetFieldAsync(apiField));
                     }
                 }
             }

--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
+++ b/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>
+    <Version>8.1.54</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/src/Sushi.Mediakiwi/Presentation/Json/AssetInfoJson.cs
+++ b/src/Sushi.Mediakiwi/Presentation/Json/AssetInfoJson.cs
@@ -1,0 +1,13 @@
+﻿namespace Sushi.Mediakiwi.Presentation.Json;
+
+public class AssetInfoJson
+{
+    public int? ID { get; set; }
+    public string Title { get; set; }
+    public int? GalleryID { get; set; }
+    public string URL { get; set; }
+    public long? FileSize { get; set; }
+    public int? Width { get; set; }
+    public int? Height { get; set; }
+    public string Description { get; set; }
+}

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.53</Version>    
+    <Version>8.1.54</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>
@@ -152,6 +152,7 @@
     <Compile Include="Framework\PagePreview.cs" />
     <Compile Include="Framework\TopListPosition.cs" />
     <Compile Include="Logic\WikiTrailExtension.cs" />
+    <Compile Include="Presentation\Json\AssetInfoJson.cs" />
     <Compile Include="Presentation\Logic\Navigation.cs" />
     <Compile Include="Presentation\Monitor.cs" />
     <Compile Include="UI\AddPageComponentControl.cs" />


### PR DESCRIPTION
An image field exposed to the API now has additional information in order to serve the FE better, here an example JSON:

`{
	"id": 921,
	"title": "640183.jpg",
	"galleryID": 1,
	"url": "https://vaultntst.blob.core.windows.net/packshots/640183.jpg",
	"fileSize": 42481,
	"width": 460,
	"height": 215,
	"description": null
}`