### PR TITLE
When a radio is in readonly, still return options from API

### DIFF
--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
+++ b/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>
+    <Version>8.1.55</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/src/Sushi.Mediakiwi/Framework/ContentInfoItem/Choice_RadioAttribute.cs
+++ b/src/Sushi.Mediakiwi/Framework/ContentInfoItem/Choice_RadioAttribute.cs
@@ -56,7 +56,8 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                 HelpText = InteractiveHelp,
                 FormSection = GetFormMapClass(),
                 Hidden = IsCloaked,
-                Options = optionsList
+                Options = optionsList, 
+                GroupName = Groupname,
             };
         }
 
@@ -459,25 +460,7 @@ namespace Sushi.Mediakiwi.Framework.ContentInfoItem
                 build.Append(GetSimpleTextElement(candidate));
             }
 
-            build.ApiResponse.Fields.Add(new Api.MediakiwiField()
-            {
-                Event = AutoPostBack ? Api.MediakiwiJSEvent.Change : Api.MediakiwiJSEvent.None,
-                Title = MandatoryWrap(Title),
-                Value = OutputText,
-                Expression = Expression,
-                PropertyName = ID,
-                PropertyType = (Property == null) ? typeof(string).FullName : Property.PropertyType.FullName,
-                VueType = Api.MediakiwiFormVueType.wimChoiceRadio,
-                Options = optionsList,
-                GroupName = Groupname,
-                ReadOnly = IsReadOnly,
-                ContentTypeID = ContentTypeSelection,
-                IsAutoPostback = AutoPostBack,
-                IsMandatory = Mandatory,
-                MaxLength = MaxValueLength,
-                HelpText = InteractiveHelp,
-                FormSection = formName
-            });
+            build.ApiResponse.Fields.Add(Task.Run(async () => await GetApiFieldAsync()).Result);
 
             return ReadCandidate(OutputText);
         }

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.54</Version>    
+    <Version>8.1.55</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>


### PR DESCRIPTION
A RadioSelect didn't return any options when it was in readonly mode. With this change it does