### PR TITLE
Allows the Images, Documents and Links list to all roles.

### DIFF
--- a/src/Sushi.Mediakiwi.API/Filters/MediakiwiConsoleFilter.cs
+++ b/src/Sushi.Mediakiwi.API/Filters/MediakiwiConsoleFilter.cs
@@ -115,14 +115,26 @@ namespace Sushi.Mediakiwi.API.Filters
                 // When the resolver created a list, assign it to the Console
                 if (resolver.List != null)
                 {
-                    var userHasAccess = await resolver.List.HasRoleAccessAsync(resolver.ApplicationUser);
-                    if (userHasAccess == false)
-                    {
-                        resolver.StatusCode = HttpStatusCode.Unauthorized;
-                    }
-                    else
+                    // Allow links, images and documents to all users
+                    if (
+                            resolver.List.Type == Data.ComponentListType.Images
+                        ||  resolver.List.Type == Data.ComponentListType.Documents
+                        ||  resolver.List.Type == Data.ComponentListType.Links)
                     {
                         console.CurrentList = resolver.List;
+                    }
+                    // Check if the user has rights to view that list.
+                    else 
+                    {
+                        var userHasAccess = await resolver.List.HasRoleAccessAsync(resolver.ApplicationUser);
+                        if (userHasAccess == false)
+                        {
+                            resolver.StatusCode = HttpStatusCode.Unauthorized;
+                        }
+                        else
+                        {
+                            console.CurrentList = resolver.List;
+                        }
                     }
                 }
 

--- a/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
+++ b/src/Sushi.Mediakiwi.API/Sushi.Mediakiwi.API.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <Authors>Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi API</Product>

--- a/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
+++ b/src/Sushi.Mediakiwi.Data.Elastic/Sushi.Mediakiwi.Data.Elastic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
+++ b/src/Sushi.Mediakiwi.Data/Sushi.Mediakiwi.Data.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <Authors>Marc Molenwijk, Mark Rienstra, Mark de Vries</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
+++ b/src/Sushi.Mediakiwi.Elastic.UI/Sushi.Mediakiwi.Elastic.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>    
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
+++ b/src/Sushi.Mediakiwi.Headless/Sushi.Mediakiwi.Headless.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <Authors>Marc Molenwijk, Mark Rienstra</Authors>
     <Company>Supershift</Company>
     <Product>Mediakiwi</Product>

--- a/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
+++ b/src/Sushi.Mediakiwi.Logic/Sushi.Mediakiwi.Logic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>
+    <Version>8.1.60</Version>
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>

--- a/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
+++ b/src/Sushi.Mediakiwi/Sushi.Mediakiwi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>8.1.59</Version>    
+    <Version>8.1.60</Version>    
     <Product>Mediakiwi</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>Supershift</Company>


### PR DESCRIPTION
The MKAPI disallowed access to the Documents, Images and Link lists.
Because giving explicit permissions for those lists isn't possible in Mediakiwi, all roles should be able to view these.

